### PR TITLE
ci(publish): wire publish-on-merge to the Tessl registry

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,47 @@
+name: Publish Plugin
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: write
+
+concurrency:
+  group: publish-plugin
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          # Full history so the changed-skills review can diff github.event.before..HEAD.
+          fetch-depth: 0
+      - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+        with:
+          python-version: "3.11"
+      - name: Install Tessl CLI
+        uses: tesslio/setup-tessl@25ec223fc0da33b41b8044ff5ab2b85235f4f91e # v2
+        with:
+          token: ${{ secrets.TESSL_TOKEN }}
+      - name: Plugin lint
+        run: tessl plugin lint
+      - name: Install dev tooling
+        run: pip install -r requirements-dev.txt
+      - name: Pyright (zero-findings gate)
+        run: pyright scripts/
+      - name: Unit tests
+        run: python -m unittest discover -s scripts/tests -p 'test_*.py'
+      - name: Skill review (changed only, threshold 85)
+        uses: jbaruch/coding-policy/.github/actions/skill-review@2d30094f068c6793b572e8fd802c598cc442a4c0 # main @ 2026-07-14
+        with:
+          threshold: "85"
+      - name: Stamp CHANGELOG with the version being published
+        uses: jbaruch/coding-policy/.github/actions/stamp-changelog@2d30094f068c6793b572e8fd802c598cc442a4c0 # main @ 2026-07-14
+      - uses: tesslio/patch-version-publish@d1363877846ebf6bc09e032e2dc8612f1d7e38dd # v1
+        with:
+          token: ${{ secrets.TESSL_TOKEN }}

--- a/.tessl-plugin/plugin.json
+++ b/.tessl-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "jbaruch/hubitat-dev",
   "version": "0.1.0",
   "description": "Context for developing and debugging Hubitat Elevation apps, drivers, and hub environment — sandbox constraints, lifecycle idioms, capability contracts, plus grounded deploy/log-tail/lint mechanisms.",
-  "private": true,
+  "private": false,
   "rules": "rules/",
   "skills": "skills/",
   "repository": "https://github.com/jbaruch/hubitat-dev",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 # Changelog
 
-## 0.1.0 — 2026-07-14
-
 ### Added
 
 - Initial plugin skeleton for `jbaruch/hubitat-dev`: manifest, README with registry badge, and the `sandbox-constraints` rule and `scaffold` skill seeds.
@@ -11,4 +9,6 @@
 - Deterministic scripts (Python, stdlib-only, unit-tested): `hub_lint.py` (sandbox + silent-failure linter, validated against real community drivers with zero false positives), `hubclient.py` (shared config + code enumerate/pull/deploy with version optimistic-concurrency), `hub_pull.py`, `hub_deploy.py`, and `hub_logtail.py` (stdlib websocket tail of `/logsocket` and `/eventsocket`, smoke-tested live). Pyright gate config (`pyrightconfig.json`) at zero findings.
 - Six skills: `scaffold`, `deploy`, `debug`, `lint-review`, `test`, and the `hub-config` action router. The `hubs.json` stateful artifact with its owner script `hubs_config.py`, schema doc, and committed `hubs.example.json` (IPs only, no secrets — Maker API credentials stay in the environment).
 - Two lift-scoped eval scenarios (`driver-fancontrol-speeds`, `sandbox-import-allowlist`) grading only counterintuitive plugin-specific facts. A measurement pass retired the zero-lift scenarios (the floor model already knows the common idioms) and reshaped criteria to drop universal-competence checks that inflated the baseline; `evals/README.md` documents the honest scope — the plugin's core value is the deterministic layer, which `plugin-evals` says not to eval.
-- CI workflow (`.github/workflows/ci.yml`) gating unit tests and the pyright zero-findings check, with `requirements-dev.txt` pinning pyright and a Dependabot config renewing the pip and github-actions pins.
+- CI workflow (`.github/workflows/ci.yml`) gating the pyright zero-findings check, unit tests, `tessl plugin lint`, and the changed-skills `tessl skill review` loop; SHA-pinned actions with a Dependabot config renewing the pip and github-actions pins.
+- Publish-on-merge (`.github/workflows/publish.yml`): every merge to `main` stamps the CHANGELOG version and publishes to the Tessl registry via `tesslio/patch-version-publish` (which runs the eval suite). Manifest set public (`private: false`).
+- Hardened every script failure path to the exit-non-zero + stderr contract (non-JSON hub responses, unwritable output, missing/malformed `hubs.json`, socket resets); shaped through a 12-round cross-family policy review.


### PR DESCRIPTION
**Author-Model:** claude-opus-4-8

## Summary

Wire publish-on-merge to the Tessl registry, per the coding-policy publish pattern.

- **`.tessl-plugin/plugin.json`**: `private: false` so the plugin can publish to the public registry.
- **`.github/workflows/publish.yml`**: on push to `main`, lint → pyright gate → tests → changed-skills `tessl skill review` → `stamp-changelog` → `tesslio/patch-version-publish` (which runs the eval suite). All actions SHA-pinned.
- **`CHANGELOG.md`**: converted to the un-headed `###` blocks the `stamp-changelog` action stamps with the `## <version> — <date>` heading on publish.

Merging this PR triggers the first publish (`0.1.0`).

## Security review (new action)

`tesslio/patch-version-publish@d136387` (v1) — the official first-party Tessl publish action (tesslio org), consumes `TESSL_TOKEN` (already configured) to bump the manifest version and publish. Reviewed for exfiltration / supply-chain / unexpected network access; standard registry publish, safe. No new secrets introduced.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
