### PR TITLE
feat(plugin): add live Z-Wave/Zigbee radio-traffic debugging (Layer 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Added
+
+- Live **radio-traffic** debugging: `scripts/hub_radiolog.py` tails the dedicated Z-Wave and Zigbee log websockets (`ws://<ip>/zwaveLogsocket`, `ws://<ip>/zigbeeLogsocket` — distinct from the driver `/logsocket`) and reads the per-frame decoded traffic. A new `mesh-health` step ties it to the snapshot: triage says which device is weak, the radio log shows it happening. Zigbee frames carry per-device `lastHopLqi`/`lastHopRssi` (the last hop into the hub) and a `sequence` counter, so `--summary` produces a live per-device signal rollup (LQI/RSSI min+avg, soft dropped-frame gaps, decoded ZCL cluster) the snapshot cannot — worst signal first. Z-Wave frames surface the controller/driver decode with per-frame RSSI. Cluster classification follows the ZCL spec (manufacturer-specific `0xFC00–0xFFFE`; `0xE000–0xEFFF` is reserved space vendors use off-spec). Log sockets and frame shapes verified live on 2.5.1.128.
+
 ## 0.1.1 — 2026-07-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Grounded against real hardware: Hubitat C-8 Pro, platform 2.5.1.125, local netwo
 - **Authoring** — apps and drivers are single Groovy 2.4 files run in a locked-down sandbox. The rules encode what that sandbox forbids and the idioms that keep an app from silently doing nothing.
 - **Deploy / pull** — push source to a hub and pull it back over the same undocumented HTTP endpoints HPM and the VS Code extension use, with the `version` optimistic-concurrency token handled for you.
 - **Debug** — tail the hub's `/logsocket` and `/eventsocket` websockets (structured JSON, no library needed) and read them against the code.
-- **Mesh health** — read the Z-Wave/Zigbee mesh detail endpoints and flag ghost/failed nodes, packet errors, weak routes, and dead devices, grounded in Hubitat's metrics and the Silabs/IEEE 802.15.4 protocol specs.
+- **Mesh health** — read the Z-Wave/Zigbee mesh detail endpoints and flag ghost/failed nodes, packet errors, weak routes, and dead devices, then tail the live radio log sockets (`zwaveLogsocket`/`zigbeeLogsocket`) for per-frame signal (Zigbee LQI/RSSI, Z-Wave per-frame RSSI) — grounded in Hubitat's metrics and the Z-Wave Alliance/Silabs/IEEE 802.15.4 protocol specs.
 - **Lint** — catch the sandbox violations and silent-failure traps (bad imports, handler-name typos, capability→command gaps, the `installed()`/`updated()` first-run trap) before you paste.
 - **Test** — take apps and drivers off-hub for real unit tests.
 

--- a/reference/endpoints.md
+++ b/reference/endpoints.md
@@ -87,7 +87,15 @@ weigh `per` against it), `per` (cumulative packet-error **count**, not a %), `av
 **Zigbee `devices[]` per-device fields:** `id`, `name`, `type`, `active` (bool), `ping`,
 `messageCount`, `lastActivity`, `lastMessage`, `shortZigbeeId` (16-bit), `zigbeeId` (64-bit IEEE).
 **No per-device LQI or RSSI is exposed here** — per-device (router) LQI is in `getChildAndRouteInfo`
-above; this snapshot is liveness + network-level only.
+above; per-frame LQI+RSSI in the radio log sockets below; this snapshot is liveness + network-level only.
+
+**Live radio log websockets** (verified 2026-07-15 on 2.5.1.128, `HTTP 101`, unmasked text frames,
+case-sensitive paths) — the per-frame decoded traffic, distinct from the driver `/logsocket`. Tail via `scripts/hub_radiolog.py`:
+
+| Socket | Frame shape (JSON per message) |
+|--------|-------------------------------|
+| `ws://<hub-ip>/zwaveLogsocket` | `{sourceLabel, plainTextMessage, deviceId, time}` — `sourceLabel` ∈ `SERIAL\|CNTRLR\|DRIVER`; node id and per-frame `RSSI: -NN dBm` live inside the decoded `plainTextMessage` text (`deviceId` is `-999` for hub-level lines) |
+| `ws://<hub-ip>/zigbeeLogsocket` | `{name, id, deviceId, profileId, clusterId, sourceEndpoint, destinationEndpoint, groupId, sequence, lastHopLqi, lastHopRssi, type, payload, time}` — **`lastHopLqi` (0–255) and `lastHopRssi` (dBm) of the last hop into the hub** (the repeater→hub link for a routed device) |
 
 **Backend vs topology — two independent axes, both verified live (the load-bearing gotcha):**
 

--- a/rules/zwave-zigbee-mesh.md
+++ b/rules/zwave-zigbee-mesh.md
@@ -39,6 +39,12 @@ unambiguous signals and rank the rest; never assert an invented cutoff.
 - Per device (snapshot): `active:false` = not communicating (dead or an unfinished join). A generic `name:"Device"` of `type:"Device"` is a join that never initialized — the Zigbee ghost.
 - Network-level problems: `networkState` ≠ `ONLINE`, `healthy:false`, or `weakChannel:true` (interference on the current channel). Zigbee uses 2.4 GHz channels 11–26; `weakChannel` overlaps busy Wi-Fi.
 
+## Live radio traffic (the log sockets)
+
+- `ws://<ip>/zwaveLogsocket` and `ws://<ip>/zigbeeLogsocket` stream per-frame decoded traffic — distinct from the driver `/logsocket`. Tail via `scripts/hub_radiolog.py`; the snapshot says who is weak, the log shows it happening.
+- Read them for live signal (Zigbee `lastHopLqi`/`lastHopRssi`, Z-Wave per-frame `RSSI: -NN dBm`), `sequence` gaps (a soft missed-frame hint, not a hard drop count — the counter is shared across the device's traffic), and which cluster/command a device uses.
+- `lastHopLqi`/`lastHopRssi` are the **last hop into the hub** — for a routed device that is the repeater→hub link, not the end device's own radio. ZCL cluster names for the common clusters; `0xFC00–0xFFFE` is manufacturer-specific, `0xE000–0xEFFF` is reserved space vendors (Tuya) use off-spec.
+
 ## Grounding sources
 
 - Field meanings: Hubitat docs (Z-Wave Details, Zigbee Details, Troubleshoot Z-Wave/Zigbee) and staff mesh-details explanations.

--- a/scripts/hub_radiolog.py
+++ b/scripts/hub_radiolog.py
@@ -83,6 +83,12 @@ def cluster_name(cluster_id) -> str:
     return "unknown"
 
 
+def _num(v):
+    """Coerce a value to a real int/float, else None — defends the ranking/aggregation against a
+    version-changed socket sending a wrong-typed numeric field (a string LQI would crash min())."""
+    return v if isinstance(v, (int, float)) and not isinstance(v, bool) else None
+
+
 def parse_zigbee_frame(f: dict) -> dict:
     """Normalize a raw Zigbee log frame to the fields worth reading/aggregating."""
     return {
@@ -94,9 +100,9 @@ def parse_zigbee_frame(f: dict) -> dict:
         "cluster": cluster_name(f.get("clusterId")),
         "srcEp": f.get("sourceEndpoint"),
         "dstEp": f.get("destinationEndpoint"),
-        "seq": f.get("sequence"),
-        "lqi": f.get("lastHopLqi"),
-        "rssi": f.get("lastHopRssi"),
+        "seq": _num(f.get("sequence")),
+        "lqi": _num(f.get("lastHopLqi")),
+        "rssi": _num(f.get("lastHopRssi")),
         "type": f.get("type"),
         "time": f.get("time"),
     }
@@ -209,6 +215,20 @@ def parse_frame(raw: dict, radio: str) -> dict:
     return parse_zigbee_frame(raw) if radio == "zigbee" else parse_zwave_frame(raw)
 
 
+def decode_frame(text: str, radio: str):
+    """Decode one raw socket text frame to a normalized dict, or None when it is not a well-formed
+    JSON object. The radio sockets are undocumented and version-sensitive, so a malformed frame OR
+    a JSON value that is not an object (a bare number, list, or string from a shape change) must
+    skip the frame, never crash the tail."""
+    try:
+        raw = json.loads(text)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(raw, dict):
+        return None
+    return parse_frame(raw, radio)
+
+
 def _run(ip: str, radio: str, filters: dict, seconds, follow, summary, as_json, out) -> int:
     request, _ = build_handshake(ip, RADIO_SOCKETS[radio])
     try:
@@ -248,11 +268,8 @@ def _run(ip: str, radio: str, filters: dict, seconds, follow, summary, as_json, 
                     break
                 if opcode not in (0x1, 0x2):
                     continue
-                try:
-                    frame = parse_frame(json.loads(payload.decode("utf-8", "replace")), radio)
-                except (json.JSONDecodeError, KeyError):
-                    continue
-                if not matches(frame, **filters):
+                frame = decode_frame(payload.decode("utf-8", "replace"), radio)
+                if frame is None or not matches(frame, **filters):
                     continue
                 if summary:
                     collected.append(frame)

--- a/scripts/hub_radiolog.py
+++ b/scripts/hub_radiolog.py
@@ -30,7 +30,8 @@ Usage:
     hub_radiolog.py --ip <addr> --radio zigbee [--name SUBSTR] [--seconds 20]
     hub_radiolog.py --ip <addr> --radio zwave  [--node 359] [--follow]
     hub_radiolog.py --ip <addr> --radio zigbee --summary [--seconds 30]   # per-device rollup
-Default: tail formatted frames for a bounded window. --summary aggregates the window instead.
+Output is structured JSON by default (per-frame JSON objects); --text switches to human-formatted
+lines for watching live by eye; --summary aggregates the window into a JSON per-device rollup.
 """
 import argparse
 import json
@@ -304,13 +305,16 @@ def main(argv=None) -> int:
     p.add_argument("--seconds", type=int, default=20)
     p.add_argument("--follow", action="store_true", help="run until interrupted")
     p.add_argument("--summary", action="store_true", help="aggregate the window into a per-device rollup")
-    p.add_argument("--json", action="store_true")
+    p.add_argument("--text", action="store_true",
+                   help="human-formatted lines instead of the default JSON (for watching live by eye)")
     args = p.parse_args(argv)
 
     filters = {"name_substr": args.name, "node": args.node,
                "device_id": args.device_id, "cluster": args.cluster}
+    # Structured JSON is the default (this is a skill-invoked deterministic script); --text opts
+    # into human-formatted lines. --summary emits a JSON rollup regardless.
     return _run(args.ip, args.radio, filters, args.seconds, args.follow,
-                args.summary, args.json, sys.stdout)
+                args.summary, not args.text, sys.stdout)
 
 
 if __name__ == "__main__":

--- a/scripts/hub_radiolog.py
+++ b/scripts/hub_radiolog.py
@@ -234,7 +234,9 @@ def _run(ip: str, radio: str, filters: dict, seconds, follow, summary, as_json, 
     try:
         sock = socket.create_connection((ip, 80), timeout=10)
     except OSError as e:
-        print(f"cannot connect to {ip}:80 — {e}", file=sys.stderr)
+        print(f"cannot connect to {ip}:80 — {e}. Confirm the hub IP is correct and reachable "
+              f"(ping it, or check hubs.json), and that Hub Security is off — the radio log "
+              f"sockets are unauthenticated local sockets on port 80.", file=sys.stderr)
         return 1
     collected = []
     try:
@@ -249,8 +251,10 @@ def _run(ip: str, radio: str, filters: dict, seconds, follow, summary, as_json, 
         sep = raw.find(b"\r\n\r\n")
         header = (raw[:sep] if sep >= 0 else raw).decode("latin1", "replace")
         if "101" not in header.split("\r\n", 1)[0]:
-            print(f"radio-log handshake failed: {header.splitlines()[0] if header else '(no response)'}",
-                  file=sys.stderr)
+            print(f"radio-log handshake failed: {header.splitlines()[0] if header else '(no response)'}. "
+                  f"The {RADIO_SOCKETS[radio]} endpoint may not exist on this firmware or Hub Security "
+                  f"may be on — verify the path against reference/endpoints.md and that the hub is on a "
+                  f"supported platform.", file=sys.stderr)
             return 1
         buf = bytearray(raw[sep + 4:]) if sep >= 0 else bytearray()
         sock.settimeout(1.0)
@@ -279,7 +283,8 @@ def _run(ip: str, radio: str, filters: dict, seconds, follow, summary, as_json, 
     except KeyboardInterrupt:
         pass
     except OSError as e:
-        print(f"radio-log connection to {ip} failed: {e}", file=sys.stderr)
+        print(f"radio-log connection to {ip} failed: {e}. The hub may have restarted or dropped "
+              f"the socket — re-run to reconnect.", file=sys.stderr)
         return 1
     finally:
         sock.close()

--- a/scripts/hub_radiolog.py
+++ b/scripts/hub_radiolog.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""Tail a Hubitat hub's live Z-Wave or Zigbee RADIO log socket and read the per-frame traffic.
+
+Distinct from hub_logtail.py: that tails the driver/app log (`/logsocket`). These are the
+dedicated radio-protocol log streams (verified live on 2.5.1.128 — see reference/endpoints.md):
+    ws://<ip>/zwaveLogsocket    (case-sensitive) — decoded Z-Wave controller/driver frames
+    ws://<ip>/zigbeeLogsocket   (case-sensitive) — structured Zigbee frame JSON
+No auth on a local hub with Hub Security off. The handshake and frame de-chunking are reused
+from hub_logtail (already unit-tested); only the parse/aggregate logic is new here.
+
+Frame shapes (grounded):
+  Z-Wave  {sourceLabel, plainTextMessage, deviceId, time}
+      sourceLabel ∈ SERIAL | CNTRLR | DRIVER; plainTextMessage is the decoded frame text, e.g.
+      "[Node 359] [REQ] [BridgeApplicationCommand] │ RSSI: -83 dBm └[Security2CC...]". The node
+      id and per-frame RSSI live IN that text (deviceId is -999 for hub-level lines), so they are
+      extracted with fixed-format regexes — everything else is passed through verbatim.
+  Zigbee  {name, id, deviceId, profileId, clusterId, sourceEndpoint, destinationEndpoint,
+           groupId, sequence, lastHopLqi, lastHopRssi, time, type, payload}
+      Carries per-frame lastHopLqi (0–255) and lastHopRssi (dBm) — the per-device signal the
+      Zigbee Details SNAPSHOT does not expose. These are the signal of the LAST HOP into the hub:
+      for a device that routes through a repeater, they reflect the repeater→hub link, not the
+      end device's own radio. `sequence` is a per-frame counter shared across the device's traffic,
+      so a gap is a soft missed-frame hint, not a hard per-cluster drop count.
+
+No absolute "bad" thresholds are asserted (Hubitat publishes none). Signal weakness is a labeled
+heuristic; the value of this tool is the live per-device signal + sequence continuity, surfaced
+for the agent to judge against rules/zwave-zigbee-mesh.md.
+
+Usage:
+    hub_radiolog.py --ip <addr> --radio zigbee [--name SUBSTR] [--seconds 20]
+    hub_radiolog.py --ip <addr> --radio zwave  [--node 359] [--follow]
+    hub_radiolog.py --ip <addr> --radio zigbee --summary [--seconds 30]   # per-device rollup
+Default: tail formatted frames for a bounded window. --summary aggregates the window instead.
+"""
+import argparse
+import json
+import re
+import socket
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+# E402: imports follow the sys.path insert so the sibling modules resolve when run as a script.
+from hub_logtail import build_handshake, iter_frames  # noqa: E402
+
+RADIO_SOCKETS = {"zwave": "/zwaveLogsocket", "zigbee": "/zigbeeLogsocket"}
+
+# Zigbee Cluster Library IDs → human names (the common home-automation clusters, per the ZCL
+# spec). Unknown ids are classified in cluster_name(), never guessed. Extend from the ZCL spec.
+ZCL_CLUSTERS = {
+    "0000": "Basic", "0001": "Power Configuration", "0003": "Identify", "0004": "Groups",
+    "0005": "Scenes", "0006": "On/Off", "0008": "Level Control", "0019": "OTA Upgrade",
+    "0020": "Poll Control", "0102": "Window Covering", "0201": "Thermostat",
+    "0300": "Color Control", "0400": "Illuminance", "0402": "Temperature",
+    "0405": "Humidity", "0406": "Occupancy", "0500": "IAS Zone", "0501": "IAS ACE",
+    "0702": "Metering", "0b04": "Electrical Measurement", "0b05": "Diagnostics",
+}
+
+_ZW_NODE_RE = re.compile(r"\[Node (\d+)\]")
+_ZW_RSSI_RE = re.compile(r"RSSI:\s*(-?\d+)\s*dBm", re.IGNORECASE)
+
+
+def cluster_name(cluster_id) -> str:
+    """Map a Zigbee clusterId (hex string, e.g. '0500') to a ZCL name, or classify it."""
+    if cluster_id is None:
+        return ""
+    key = str(cluster_id).lower().removeprefix("0x").rjust(4, "0")
+    if key in ZCL_CLUSTERS:
+        return ZCL_CLUSTERS[key]
+    try:
+        val = int(key, 16)
+    except ValueError:
+        return "unknown"
+    # ZCL manufacturer-specific range is 0xFC00–0xFFFE (requires a manufacturer code); 0xFFFF is
+    # not a usable cluster id. 0xE000–0xEFFF is RESERVED ZCL space that Tuya-family devices (e.g.
+    # the presence sensors reporting E002) squat on off-spec — vendor-custom, NOT the ZCL
+    # manufacturer range. Keep the two distinct (verified against the ZCL spec, 2026-07-15).
+    if 0xFC00 <= val <= 0xFFFE:
+        return "manufacturer-specific"
+    if 0xE000 <= val <= 0xEFFF:
+        return "vendor-custom (reserved range)"
+    return "unknown"
+
+
+def parse_zigbee_frame(f: dict) -> dict:
+    """Normalize a raw Zigbee log frame to the fields worth reading/aggregating."""
+    return {
+        "radio": "zigbee",
+        "name": f.get("name") or "",
+        "id": f.get("id"),
+        "deviceId": f.get("deviceId"),
+        "clusterId": f.get("clusterId"),
+        "cluster": cluster_name(f.get("clusterId")),
+        "srcEp": f.get("sourceEndpoint"),
+        "dstEp": f.get("destinationEndpoint"),
+        "seq": f.get("sequence"),
+        "lqi": f.get("lastHopLqi"),
+        "rssi": f.get("lastHopRssi"),
+        "type": f.get("type"),
+        "time": f.get("time"),
+    }
+
+
+def parse_zwave_frame(f: dict) -> dict:
+    """Normalize a raw Z-Wave log frame. Node id and RSSI are pulled from the decoded text."""
+    text = f.get("plainTextMessage") or ""
+    node = _ZW_NODE_RE.search(text)
+    rssi = _ZW_RSSI_RE.search(text)
+    return {
+        "radio": "zwave",
+        "sourceLabel": f.get("sourceLabel"),
+        "node": int(node.group(1)) if node else None,
+        "rssi": int(rssi.group(1)) if rssi else None,
+        "text": " ".join(text.split()),  # collapse the multi-line decoded block to one line
+        "time": f.get("time"),
+    }
+
+
+def matches(frame: dict, name_substr=None, node=None, device_id=None, cluster=None) -> bool:
+    """Pure filter predicate over a normalized frame (either radio)."""
+    if name_substr and name_substr.lower() not in (frame.get("name") or "").lower():
+        return False
+    if node is not None and frame.get("node") != node:
+        return False
+    if device_id is not None and str(frame.get("deviceId")) != str(device_id):
+        return False
+    if cluster and cluster.lower() not in (frame.get("cluster") or "").lower() \
+            and cluster.lower() != str(frame.get("clusterId") or "").lower():
+        return False
+    return True
+
+
+def format_frame(frame: dict, as_json: bool = False) -> str:
+    if as_json:
+        return json.dumps(frame, sort_keys=True)
+    t = frame.get("time", "")
+    if frame["radio"] == "zigbee":
+        return (f"{t} {frame['name'] or ('id ' + str(frame['id']))}: {frame['cluster']} "
+                f"(0x{str(frame['clusterId']).lower()}) ep{frame['srcEp']}->{frame['dstEp']} "
+                f"seq={frame['seq']} lqi={frame['lqi']} rssi={frame['rssi']}dBm")
+    node = f"Node {frame['node']}" if frame["node"] is not None else "hub"
+    rssi = f" rssi={frame['rssi']}dBm" if frame["rssi"] is not None else ""
+    return f"{t} [{frame['sourceLabel']}] {node}{rssi}: {frame['text']}"
+
+
+class SequenceTracker:
+    """Per-device Zigbee sequence continuity. A jump > 1 (mod 256) between consecutive frames
+    from the same device means intervening frames were not heard by the hub — a soft drop signal,
+    not a hard error (other traffic and frame types share the counter)."""
+
+    def __init__(self):
+        self.last = {}
+        self.gaps = {}
+
+    def observe(self, device_key, seq) -> int:
+        """Return the gap size for this frame (0 = contiguous/first), and accumulate per device."""
+        if seq is None or device_key is None:
+            return 0
+        prev = self.last.get(device_key)
+        self.last[device_key] = seq
+        if prev is None:
+            return 0
+        delta = (seq - prev) % 256
+        gap = delta - 1 if delta >= 1 else 0
+        if gap > 0:
+            self.gaps[device_key] = self.gaps.get(device_key, 0) + gap
+        return gap
+
+
+def summarize(frames: list) -> dict:
+    """Pure. Aggregate a window of normalized frames into a per-device rollup: frame count,
+    signal min/avg (LQI + RSSI for Zigbee, RSSI for Z-Wave), and observed sequence gaps."""
+    tracker = SequenceTracker()
+    devices = {}
+    for fr in frames:
+        if fr["radio"] == "zigbee":
+            key = fr["name"] or f"id:{fr['id']}"
+        else:
+            key = f"Node {fr['node']}" if fr.get("node") is not None else "hub"
+        tracker.observe(key, fr.get("seq"))  # same key as the rollup so gaps attach
+        d = devices.setdefault(key, {"frames": 0, "lqi": [], "rssi": [], "clusters": set()})
+        d["frames"] += 1
+        if fr.get("lqi") is not None:
+            d["lqi"].append(fr["lqi"])
+        if fr.get("rssi") is not None:
+            d["rssi"].append(fr["rssi"])
+        if fr.get("cluster"):
+            d["clusters"].add(fr["cluster"])
+
+    def stat(xs):
+        return None if not xs else {"min": min(xs), "avg": round(sum(xs) / len(xs), 1), "n": len(xs)}
+
+    out = {}
+    for key, d in devices.items():
+        out[key] = {
+            "frames": d["frames"],
+            "lqi": stat(d["lqi"]),
+            "rssi": stat(d["rssi"]),
+            "clusters": sorted(d["clusters"]),
+            "sequence_gaps": tracker.gaps.get(key, 0),
+        }
+    # worst signal first: sort by average RSSI ascending (weakest at the top)
+    return {"device_count": len(out), "devices": dict(sorted(out.items(),
+            key=lambda kv: (kv[1]["rssi"]["avg"] if kv[1]["rssi"] else 0)))}
+
+
+def parse_frame(raw: dict, radio: str) -> dict:
+    return parse_zigbee_frame(raw) if radio == "zigbee" else parse_zwave_frame(raw)
+
+
+def _run(ip: str, radio: str, filters: dict, seconds, follow, summary, as_json, out) -> int:
+    request, _ = build_handshake(ip, RADIO_SOCKETS[radio])
+    try:
+        sock = socket.create_connection((ip, 80), timeout=10)
+    except OSError as e:
+        print(f"cannot connect to {ip}:80 — {e}", file=sys.stderr)
+        return 1
+    collected = []
+    try:
+        sock.sendall(request)
+        sock.settimeout(5.0)
+        raw = b""
+        while b"\r\n\r\n" not in raw and len(raw) < 8192:
+            chunk = sock.recv(4096)
+            if not chunk:
+                break
+            raw += chunk
+        sep = raw.find(b"\r\n\r\n")
+        header = (raw[:sep] if sep >= 0 else raw).decode("latin1", "replace")
+        if "101" not in header.split("\r\n", 1)[0]:
+            print(f"radio-log handshake failed: {header.splitlines()[0] if header else '(no response)'}",
+                  file=sys.stderr)
+            return 1
+        buf = bytearray(raw[sep + 4:]) if sep >= 0 else bytearray()
+        sock.settimeout(1.0)
+        deadline = None if follow else time.monotonic() + seconds
+        while follow or deadline is None or time.monotonic() < deadline:
+            try:
+                chunk = sock.recv(8192)
+            except socket.timeout:
+                continue
+            if not chunk:
+                break
+            buf.extend(chunk)
+            for opcode, payload in iter_frames(buf):
+                if opcode == 0x8:
+                    break
+                if opcode not in (0x1, 0x2):
+                    continue
+                try:
+                    frame = parse_frame(json.loads(payload.decode("utf-8", "replace")), radio)
+                except (json.JSONDecodeError, KeyError):
+                    continue
+                if not matches(frame, **filters):
+                    continue
+                if summary:
+                    collected.append(frame)
+                else:
+                    out.write(format_frame(frame, as_json) + "\n")
+                    out.flush()
+    except KeyboardInterrupt:
+        pass
+    except OSError as e:
+        print(f"radio-log connection to {ip} failed: {e}", file=sys.stderr)
+        return 1
+    finally:
+        sock.close()
+    if summary:
+        out.write(json.dumps(summarize(collected), indent=2, default=str) + "\n")
+    return 0
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(description="Tail a Hubitat Z-Wave/Zigbee radio log socket.")
+    p.add_argument("--ip", required=True)
+    p.add_argument("--radio", required=True, choices=["zwave", "zigbee"])
+    p.add_argument("--name", help="Zigbee device-name substring filter")
+    p.add_argument("--node", type=int, help="Z-Wave node id filter")
+    p.add_argument("--device-id", help="Hubitat device id filter")
+    p.add_argument("--cluster", help="Zigbee cluster filter (name or hex id)")
+    p.add_argument("--seconds", type=int, default=20)
+    p.add_argument("--follow", action="store_true", help="run until interrupted")
+    p.add_argument("--summary", action="store_true", help="aggregate the window into a per-device rollup")
+    p.add_argument("--json", action="store_true")
+    args = p.parse_args(argv)
+
+    filters = {"name_substr": args.name, "node": args.node,
+               "device_id": args.device_id, "cluster": args.cluster}
+    return _run(args.ip, args.radio, filters, args.seconds, args.follow,
+                args.summary, args.json, sys.stdout)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_hub_radiolog.py
+++ b/scripts/tests/test_hub_radiolog.py
@@ -54,6 +54,30 @@ class TestParseZigbee(unittest.TestCase):
         self.assertEqual(f["name"], "Stairs Top Motion Sensor")
 
 
+class TestDecodeFrame(unittest.TestCase):
+    def test_valid_object_frame_decodes(self):
+        import json
+        f = m.decode_frame(json.dumps(ZB_RAW), "zigbee")
+        self.assertEqual(f["cluster"], "IAS Zone")
+
+    def test_malformed_json_is_none(self):
+        self.assertIsNone(m.decode_frame("{not json", "zigbee"))
+
+    def test_json_valid_but_not_an_object_is_none(self):
+        # the version-sensitive socket could emit a bare number/list/string — must skip, not crash
+        for text in ("123", "[1, 2, 3]", '"a string"', "null"):
+            self.assertIsNone(m.decode_frame(text, "zigbee"))
+            self.assertIsNone(m.decode_frame(text, "zwave"))
+
+    def test_wrong_typed_numeric_field_does_not_crash_aggregation(self):
+        import json
+        bad = {**ZB_RAW, "lastHopLqi": "oops", "lastHopRssi": None, "sequence": "x"}
+        f = m.decode_frame(json.dumps(bad), "zigbee")
+        self.assertIsNone(f["lqi"])
+        self.assertIsNone(f["rssi"])
+        m.summarize([f])  # must not raise on the wrong-typed frame
+
+
 class TestParseZwave(unittest.TestCase):
     def test_node_and_rssi_extracted_from_text(self):
         f = m.parse_zwave_frame(ZW_RAW)

--- a/scripts/tests/test_hub_radiolog.py
+++ b/scripts/tests/test_hub_radiolog.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Tests for scripts/hub_radiolog.py — pure frame parsing, filtering, cluster naming, sequence
+gap tracking, and window summarization over fixture frames (no network)."""
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent.parent / "hub_radiolog.py"
+spec = importlib.util.spec_from_file_location("hub_radiolog", SCRIPT)
+assert spec and spec.loader
+m = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(m)
+
+# Real shapes captured from the live sockets on 2.5.1.128.
+ZB_RAW = {"name": "Stairs Top Motion Sensor", "id": 26851, "deviceId": 501, "profileId": "0104",
+          "clusterId": "0500", "sourceEndpoint": "01", "destinationEndpoint": "01",
+          "groupId": "0000", "sequence": 85, "lastHopLqi": 204, "lastHopRssi": -49,
+          "time": "2026-07-15 12:11:32.769", "type": "zigbeeRx", "payload": "00"}
+ZW_RAW = {"sourceLabel": "DRIVER", "deviceId": -999,
+          "plainTextMessage": "« [Node 359] [REQ] [BridgeApplicationCommand]\n     │ RSSI: -83 dBm\n     └[Security2CCMessageEncapsulation]",
+          "time": "2026-07-15 12:10:43.446"}
+
+
+class TestClusterName(unittest.TestCase):
+    def test_known_cluster(self):
+        self.assertEqual(m.cluster_name("0500"), "IAS Zone")
+        self.assertEqual(m.cluster_name("0006"), "On/Off")
+
+    def test_hex_prefix_and_padding(self):
+        self.assertEqual(m.cluster_name("0x6"), "On/Off")
+
+    def test_manufacturer_specific_range(self):
+        # ZCL manufacturer-specific is 0xFC00–0xFFFE
+        self.assertEqual(m.cluster_name("FC01"), "manufacturer-specific")
+        self.assertEqual(m.cluster_name("FFFE"), "manufacturer-specific")
+
+    def test_vendor_custom_reserved_range_not_manufacturer(self):
+        # 0xE000–0xEFFF is reserved space Tuya-family devices squat on — NOT manufacturer-specific
+        self.assertEqual(m.cluster_name("E002"), "vendor-custom (reserved range)")
+        self.assertEqual(m.cluster_name("E000"), "vendor-custom (reserved range)")
+
+    def test_unknown(self):
+        self.assertEqual(m.cluster_name("0999"), "unknown")
+        self.assertEqual(m.cluster_name("FFFF"), "unknown")  # 0xFFFF is not a usable cluster id
+
+
+class TestParseZigbee(unittest.TestCase):
+    def test_fields_and_cluster(self):
+        f = m.parse_zigbee_frame(ZB_RAW)
+        self.assertEqual(f["radio"], "zigbee")
+        self.assertEqual(f["cluster"], "IAS Zone")
+        self.assertEqual((f["lqi"], f["rssi"], f["seq"]), (204, -49, 85))
+        self.assertEqual(f["name"], "Stairs Top Motion Sensor")
+
+
+class TestParseZwave(unittest.TestCase):
+    def test_node_and_rssi_extracted_from_text(self):
+        f = m.parse_zwave_frame(ZW_RAW)
+        self.assertEqual(f["radio"], "zwave")
+        self.assertEqual(f["node"], 359)
+        self.assertEqual(f["rssi"], -83)
+        self.assertEqual(f["sourceLabel"], "DRIVER")
+        self.assertNotIn("\n", f["text"])  # multi-line block collapsed
+
+    def test_hub_line_without_node(self):
+        f = m.parse_zwave_frame({"sourceLabel": "SERIAL", "deviceId": -999,
+                                 "plainTextMessage": "» [ACK] (0x06)", "time": "t"})
+        self.assertIsNone(f["node"])
+        self.assertIsNone(f["rssi"])
+
+
+class TestMatches(unittest.TestCase):
+    def test_zigbee_name_filter(self):
+        f = m.parse_zigbee_frame(ZB_RAW)
+        self.assertTrue(m.matches(f, name_substr="stairs"))
+        self.assertFalse(m.matches(f, name_substr="kitchen"))
+
+    def test_zwave_node_filter(self):
+        f = m.parse_zwave_frame(ZW_RAW)
+        self.assertTrue(m.matches(f, node=359))
+        self.assertFalse(m.matches(f, node=360))
+
+    def test_cluster_filter_by_name_or_id(self):
+        f = m.parse_zigbee_frame(ZB_RAW)
+        self.assertTrue(m.matches(f, cluster="IAS Zone"))
+        self.assertTrue(m.matches(f, cluster="0500"))
+        self.assertFalse(m.matches(f, cluster="On/Off"))
+
+
+class TestSequenceTracker(unittest.TestCase):
+    def test_contiguous_no_gap(self):
+        t = m.SequenceTracker()
+        self.assertEqual(t.observe("dev", 10), 0)  # first
+        self.assertEqual(t.observe("dev", 11), 0)  # contiguous
+        self.assertEqual(t.gaps.get("dev", 0), 0)
+
+    def test_gap_detected_and_accumulated(self):
+        t = m.SequenceTracker()
+        t.observe("dev", 10)
+        self.assertEqual(t.observe("dev", 14), 3)  # 3 missing between 10 and 14
+        self.assertEqual(t.gaps["dev"], 3)
+
+    def test_wraparound(self):
+        t = m.SequenceTracker()
+        t.observe("dev", 255)
+        self.assertEqual(t.observe("dev", 0), 0)  # 255 -> 0 is contiguous mod 256
+
+    def test_independent_devices(self):
+        t = m.SequenceTracker()
+        t.observe("a", 5); t.observe("b", 100)
+        self.assertEqual(t.observe("a", 6), 0)
+        self.assertEqual(t.observe("b", 105), 4)
+        self.assertEqual(t.gaps.get("a", 0), 0)
+
+
+class TestSummarize(unittest.TestCase):
+    def _zb(self, name, seq, lqi, rssi):
+        return m.parse_zigbee_frame({**ZB_RAW, "name": name, "sequence": seq,
+                                     "lastHopLqi": lqi, "lastHopRssi": rssi})
+
+    def test_per_device_rollup_and_worst_first(self):
+        frames = [self._zb("Strong", 1, 200, -40), self._zb("Strong", 2, 210, -42),
+                  self._zb("Weak", 10, 90, -85)]
+        s = m.summarize(frames)
+        self.assertEqual(s["device_count"], 2)
+        self.assertEqual(list(s["devices"])[0], "Weak")  # weakest avg RSSI first
+        self.assertEqual(s["devices"]["Strong"]["frames"], 2)
+        self.assertEqual(s["devices"]["Strong"]["rssi"], {"min": -42, "avg": -41.0, "n": 2})
+
+    def test_sequence_gaps_attach_to_device(self):
+        frames = [self._zb("Flaky", 1, 100, -70), self._zb("Flaky", 5, 100, -70)]
+        s = m.summarize(frames)
+        self.assertEqual(s["devices"]["Flaky"]["sequence_gaps"], 3)
+
+    def test_zwave_rollup_by_node(self):
+        frames = [m.parse_zwave_frame(ZW_RAW), m.parse_zwave_frame(ZW_RAW)]
+        s = m.summarize(frames)
+        self.assertIn("Node 359", s["devices"])
+        self.assertEqual(s["devices"]["Node 359"]["rssi"], {"min": -83, "avg": -83.0, "n": 2})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/mesh-health/SKILL.md
+++ b/skills/mesh-health/SKILL.md
@@ -48,7 +48,8 @@ Correlate a flagged node against the reported symptom. Proceed to Step 5.
 ## Step 5 — Watch the live radio traffic
 
 The snapshot says *who* is weak; the radio log streams say *what is happening on the air* — per-frame
-signal, retransmits, and dropped frames. When a suspect device needs confirming, tail its live traffic:
+signal (LQI/RSSI) and sequence continuity (soft missed-frame hints). When a suspect device needs
+confirming, tail its live traffic:
 
 ```
 python3 .tessl/plugins/jbaruch/hubitat-dev/scripts/hub_radiolog.py --ip <addr> --radio zigbee|zwave \

--- a/skills/mesh-health/SKILL.md
+++ b/skills/mesh-health/SKILL.md
@@ -45,7 +45,24 @@ Interpret, don't threshold — apply `rules/zwave-zigbee-mesh.md`:
 
 Correlate a flagged node against the reported symptom. Proceed to Step 5.
 
-## Step 5 — Report the Diagnosis
+## Step 5 — Watch the live radio traffic
+
+The snapshot says *who* is weak; the radio log streams say *what is happening on the air* — per-frame
+signal, retransmits, and dropped frames. When a suspect device needs confirming, tail its live traffic:
+
+```
+python3 .tessl/plugins/jbaruch/hubitat-dev/scripts/hub_radiolog.py --ip <addr> --radio zigbee|zwave \
+    [--name "<device>" | --node <n>] [--summary] [--seconds N | --follow]
+```
+
+Argument and frame contract: `scripts/hub_radiolog.py` module docstring. `--summary` aggregates a window
+into a per-device rollup (frame count, LQI/RSSI min+avg, `sequence_gaps`), worst-signal first — the live
+counterpart to the snapshot. **Zigbee frames carry per-device `lastHopLqi`/`lastHopRssi`** (the last hop
+into the hub — a repeater's link for a routed device). Read values against `rules/zwave-zigbee-mesh.md`
+(higher LQI/RSSI better; no absolute cutoff). Skip this step for a whole-network health check that needs
+no per-device confirmation. Proceed to Step 6.
+
+## Step 6 — Report the Diagnosis
 
 State the diagnosis with the evidence (the flag or ranking that showed it) and the grounded fix.
 Ghost/failed-node removal and channel changes are **hub-UI actions** (Z-Wave Details → Refresh then

--- a/skills/mesh-health/SKILL.md
+++ b/skills/mesh-health/SKILL.md
@@ -55,8 +55,8 @@ python3 .tessl/plugins/jbaruch/hubitat-dev/scripts/hub_radiolog.py --ip <addr> -
     [--name "<device>" | --node <n>] --summary [--seconds N]
 ```
 
-Invoke with `--summary` (or `--json` for raw per-frame JSON) so the output is structured JSON for you to
-read, not human-formatted lines. Argument and frame contract: `scripts/hub_radiolog.py` module docstring.
+The script emits structured JSON by default; `--summary` gives the per-device rollup you want for
+diagnosis (raw per-frame JSON otherwise). Argument and frame contract: `scripts/hub_radiolog.py` module docstring.
 `--summary` aggregates the window into a per-device rollup (frame count, LQI/RSSI min+avg, `sequence_gaps`),
 worst-signal first — the live counterpart to the snapshot. **Zigbee frames carry per-device
 `lastHopLqi`/`lastHopRssi`** (the last hop into the hub — a repeater's link for a routed device). Read

--- a/skills/mesh-health/SKILL.md
+++ b/skills/mesh-health/SKILL.md
@@ -52,15 +52,16 @@ signal, retransmits, and dropped frames. When a suspect device needs confirming,
 
 ```
 python3 .tessl/plugins/jbaruch/hubitat-dev/scripts/hub_radiolog.py --ip <addr> --radio zigbee|zwave \
-    [--name "<device>" | --node <n>] [--summary] [--seconds N | --follow]
+    [--name "<device>" | --node <n>] --summary [--seconds N]
 ```
 
-Argument and frame contract: `scripts/hub_radiolog.py` module docstring. `--summary` aggregates a window
-into a per-device rollup (frame count, LQI/RSSI min+avg, `sequence_gaps`), worst-signal first — the live
-counterpart to the snapshot. **Zigbee frames carry per-device `lastHopLqi`/`lastHopRssi`** (the last hop
-into the hub — a repeater's link for a routed device). Read values against `rules/zwave-zigbee-mesh.md`
-(higher LQI/RSSI better; no absolute cutoff). Skip this step for a whole-network health check that needs
-no per-device confirmation. Proceed to Step 6.
+Invoke with `--summary` (or `--json` for raw per-frame JSON) so the output is structured JSON for you to
+read, not human-formatted lines. Argument and frame contract: `scripts/hub_radiolog.py` module docstring.
+`--summary` aggregates the window into a per-device rollup (frame count, LQI/RSSI min+avg, `sequence_gaps`),
+worst-signal first — the live counterpart to the snapshot. **Zigbee frames carry per-device
+`lastHopLqi`/`lastHopRssi`** (the last hop into the hub — a repeater's link for a routed device). Read
+values against `rules/zwave-zigbee-mesh.md` (higher LQI/RSSI better; no absolute cutoff). Skip this step
+for a whole-network health check that needs no per-device confirmation. Proceed to Step 6.
 
 ## Step 6 — Report the Diagnosis
 


### PR DESCRIPTION
## Layer 2 of the mesh-debug series — live radio traffic

Builds on Layer 1 (mesh-health snapshot triage, shipped in 0.1.1). Where the snapshot says *which* device is weak, this tails the hub's dedicated radio log sockets to show *what is happening on the air*, per frame.

### What's here

- **`scripts/hub_radiolog.py`** (+ tests) — tails `ws://<ip>/zwaveLogsocket` and `ws://<ip>/zigbeeLogsocket` (distinct from the driver `/logsocket`) and parses the per-frame decoded traffic. `--summary` aggregates a window into a per-device rollup (frame count, LQI/RSSI min+avg, soft dropped-frame `sequence_gaps`, decoded ZCL cluster), worst-signal first. Reuses the tested handshake/frame helpers from `hub_logtail.py`.
- New **`mesh-health` Step 5** ("Watch the live radio traffic") ties it to the snapshot flow.
- `rules/zwave-zigbee-mesh.md` + `reference/endpoints.md` updated with the log sockets.

### Why this matters

The Zigbee Details **snapshot exposes no per-device LQI/RSSI** — but every `zigbeeLogsocket` frame carries `lastHopLqi` (0–255) and `lastHopRssi` (dBm). So this is the only live per-device Zigbee signal source. (Honest caveat, in the code and rule: these are the *last hop into the hub* — a repeater's link for a routed device, not the end device's own radio.)

### Grounded, spec-audited

Frame shapes verified live on 2.5.1.128 (both radios). ZCL cluster classification follows the spec after a full audit: manufacturer-specific is `0xFC00–0xFFFE`; `0xE000–0xEFFF` is reserved space Tuya-family devices use off-spec (labeled `vendor-custom`, not manufacturer-specific).

### Verification

pyright 0 findings · 127 unit tests green · `tessl plugin lint` valid · `tessl skill review` 100%.

**Author-Model:** claude-opus-4-8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QLPkvpAdHzvuCzZMKcsFyk
