### PR TITLE
docs(ui): add Playwright UI automation rule and reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Added
+
+- **UI automation via Playwright MCP** for the operations the hub exposes only through its web UI — installing an app instance, configuring built-in/community apps (Room Lighting, Notifications, CoCoHue, HubiThings Replica), deleting a device or app, importing devices, reading a backup. New always-on `ui-automation` rule plus `reference/playwright-ui.md` document the navigate → snapshot → act → verify workflow and nine hard-won gotchas, three of them load-bearing: MDL/Vue pickers keep selection in a `label.is-checked` class while `input.checked` stays `false` (reading the property nearly wiped 15 selected scene members); a device input persists on the page's **Done** over a WebSocket, not the picker's "Update" or any observable HTTP, so synthetic `.checked`/events do not stick; and Room Lighting re-captures the physical state of every scene light on "Done with Room Lights" (an on light silently overwrote a live scene before this was understood — set captured state directly instead). Also documents `statusJson` reporting device inputs as `None` (verify via `configure/json`), `element.click()` in `browser_evaluate` not firing framework handlers, the `mainPage`-vs-sub-page column-layout mismatch, `removeButton: false` apps being remove-not-automatable, and backups being a restore-only encrypted H2 blob. Grounded on a C-8 Pro with Hub Security off; the Playwright MCP is added at user scope, not shipped with the plugin.
+
 ## 0.1.4 — 2026-07-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Grounded against real hardware: Hubitat C-8 Pro, platform 2.5.1.125, local netwo
 - **Mesh health** — read the Z-Wave/Zigbee mesh detail endpoints and flag ghost/failed nodes, packet errors, weak routes, and dead devices, then tail the live radio log sockets (`zwaveLogsocket`/`zigbeeLogsocket`) for per-frame signal (Zigbee LQI/RSSI, Z-Wave per-frame RSSI) — grounded in Hubitat's metrics and the Z-Wave Alliance/Silabs/IEEE 802.15.4 protocol specs.
 - **Lint** — catch the sandbox violations and silent-failure traps (bad imports, handler-name typos, capability→command gaps, the `installed()`/`updated()` first-run trap) before you paste.
 - **Test** — take apps and drivers off-hub for real unit tests.
+- **UI automation** — for the operations the hub exposes only through its web UI (installing an app instance, configuring built-in/community apps, deleting a device or app, importing devices, reading a backup), drive it with the Playwright MCP — with the Vue/MDL selection traps and silent-failure gotchas documented so a mutation is never assumed to have stuck (`reference/playwright-ui.md`).
 
 ## Rules
 
@@ -29,6 +30,7 @@ All rules are always-on — installing the plugin means you want this context.
 | [groovy-gotchas](rules/groovy-gotchas.md) | Silent-failure traps the compiler misses: string handler names, `0`-is-falsy, null device inputs, reserved names. |
 | [multi-hub-topology](rules/multi-hub-topology.md) | Code is per-hub-by-IP, devices can mesh; local-no-security assumption; the deploy version token. |
 | [zwave-zigbee-mesh](rules/zwave-zigbee-mesh.md) | What the Z-Wave/Zigbee mesh metrics mean, the two-scale `lwrRssi` backend trap, and what counts as a real problem. |
+| [ui-automation](rules/ui-automation.md) | Driving the hub web UI with Playwright for UI-only operations — the Vue/MDL selection traps, `statusJson` blind spot, Room Lighting recapture, and verify-every-mutation. |
 
 ## Skills
 

--- a/reference/playwright-ui.md
+++ b/reference/playwright-ui.md
@@ -1,0 +1,96 @@
+# Driving the Hubitat UI with Playwright MCP (grounded)
+
+Observed live against a **C-8 Pro**, local network, **Hub Security off**. The `hubitat-dev`
+toolset is HTTP/code only (`reference/endpoints.md`). A class of real tasks has **no documented
+HTTP/code endpoint** and is reachable only through the hub's web UI at `http://<hub-ip>:8080`.
+For those, drive the UI with the **Playwright MCP** — a headless Chromium that needs no browser
+extension and no auth on a Hub-Security-off hub. Several gotchas below cost real time; one
+silently overwrote a live Room Lighting scene before it was understood.
+
+## When the UI is the only path
+
+HTTP/code (`reference/endpoints.md`) handles source deploy/pull, log/event tail, mesh detail,
+and device control via Maker API. The UI is required for:
+
+- Installing an **app instance** — Add User App → configure pages → **Done**.
+- Configuring **built-in / community apps** — Room Lighting, Notifications, Device Activity
+  Check, CoCoHue, HubiThings Replica.
+- **Deleting** a device or an app (also a physical step for radio devices — `rules/zwave-zigbee-mesh.md`).
+- Importing devices (e.g. CoCoHue "Select Lights").
+- Reading the backup list / downloading a backup.
+
+Reach for HTTP first every time; open the UI only when the operation is on this list.
+
+## Setup
+
+The Playwright MCP is added once at **user scope**, not shipped with this plugin:
+
+```
+claude mcp add playwright -s user -- npx -y @playwright/mcp@latest
+```
+
+It runs its own Chromium against the hub's IP. Adding it needs a Claude Code restart before its
+tools load. The tools used below are the standard Playwright MCP surface: `browser_navigate`,
+`browser_snapshot`, `browser_click`, `browser_type`, `browser_evaluate`, `browser_take_screenshot`.
+
+## The workflow
+
+1. `browser_navigate` to the page (`http://<hub-ip>:8080/installedapp/configure/<id>`, a device
+   edit page, `/hub/backup`, …).
+2. `browser_snapshot` — read the **accessibility tree**, not a screenshot (see gotcha 9).
+3. Act with **real** `browser_click` / `browser_type` — never `element.click()` inside
+   `browser_evaluate` (gotcha 4).
+4. **Verify every mutation** by re-reading the DOM or the hub's `configure/json` — these UIs fail
+   silently. For a device input, `statusJson` lies (gotcha 3); read `configure/json` or run the code.
+5. For destructive/irreversible actions (device/app delete, scene edits), read the confirm dialog
+   first and re-verify after.
+
+## The gotchas
+
+1. **MDL/Vue checkbox & radio pickers lie about `input.checked`.** The device/capability pickers
+   (notifier selection, Room Lighting "Devices to Automate") render selection state as a CSS class
+   on the label — `label.is-checked` — while the underlying `input.checked` stays `false`. Read the
+   class, never the property. Reading the property once made 15 selected members look unselected and
+   nearly wiped them.
+
+2. **Selections persist over a WebSocket, not observable HTTP.** The picker's "Update" button fires
+   no HTTP request; the value commits on the page's **Done**. To make a device input actually save,
+   do a genuine trusted click on the option, then Done. JS-forcing `.checked` or dispatching synthetic
+   events bypasses the Vue model and does not persist.
+
+3. **`statusJson` hides device settings.** `/installedapp/statusJson/<id>` reports capability/device
+   inputs as `None` even when set. Verify device inputs via
+   `/installedapp/configure/json/<id>/<page>` (the `settings` object), or by running the code.
+
+4. **`element.click()` in `browser_evaluate` does not trigger framework handlers** (jQuery/Vue
+   toggles, MDL buttons). Use a real Playwright `browser_click` for anything with a bound handler.
+
+5. **Room Lighting auto-captures physical state.** Adding devices to a Room Lighting scene and
+   clicking "Done with Room Lights" **re-captures the current physical state of every light in the
+   scene** — if the lights happen to be on, it silently overwrites the scene. Instead: add members,
+   then set each device's captured state directly (click the Level cell → the `dimLA` number input;
+   click the Switch cell → the on/off toggles). Capture is optional. Avoid "Re-Capture" unless the
+   physical lights are already in the exact desired state.
+
+6. **`mainPage` and sub-pages have different table column layouts.** Do not compare a device table
+   read on `mainPage` against one on `.../onDevicesPage` by column index — the misalignment produces
+   a wrong diagnosis. Identify columns by their hidden `settings[...]` input names or by content
+   pattern.
+
+7. **Some apps set `removeButton: false`** (e.g. HubiThings Replica) and expose no UI remove; the
+   platform also rejects synthetic removal endpoints. Note these as **remove not automatable**.
+
+8. **Backups are a proprietary format.** `/hub/backupDB?fileName=...` downloads an H2 MVStore file
+   wrapped/encrypted behind a `-- H2 0.5/B --` header; external H2 tools reject it ("Store header is
+   corrupt"). Backups are **restore-to-hub only** (full-hub, all-or-nothing) — a single app's
+   settings cannot be extracted from one.
+
+9. **Screenshots aren't visually inspectable** in this setup. Rely on `browser_snapshot` (the
+   accessibility tree) and DOM reads via `browser_evaluate` for state — not `browser_take_screenshot`.
+
+## Grounding
+
+Endpoints and hub behavior verified on a C-8 Pro with Hub Security off (baseline
+`reference/endpoints.md`). Gotchas 1, 2, and 5 are the load-bearing ones — each was reached the
+expensive way in real usage, and 5 corrupted a live scene. The Vue/MDL selection model and the
+`statusJson` vs `configure/json` split are hub-firmware behavior; re-verify after a platform update.

--- a/rules/ui-automation.md
+++ b/rules/ui-automation.md
@@ -1,0 +1,35 @@
+---
+alwaysApply: true
+description: Driving the Hubitat web UI with Playwright for UI-only operations — the silent-failure traps and the read-the-framework-state rule
+---
+
+# UI Automation
+
+The `hubitat-dev` toolset is HTTP/code only. A class of operations has no documented endpoint and
+is reachable only through the hub web UI at `http://<hub-ip>:8080`, driven with the Playwright MCP.
+Selectors, setup, the full workflow, and every gotcha's detail live in `reference/playwright-ui.md`.
+
+## Reach for HTTP first
+
+- Source deploy/pull, log/event tail, mesh detail, and device control (Maker API) have grounded HTTP endpoints — use them (`reference/endpoints.md`).
+- Drive the UI only for the operations with no endpoint: installing an app instance, configuring built-in/community apps (Room Lighting, Notifications, CoCoHue, HubiThings Replica), deleting a device or app, importing devices, reading/downloading a backup.
+
+## Read state the way the framework stores it
+
+- MDL/Vue checkbox and radio pickers keep selection in a `label.is-checked` CSS class, and leave `input.checked` at `false`. Read the class, never the property — reading `input.checked` once made 15 selected members look unselected and nearly wiped them.
+- Act with real `browser_click` / `browser_type`. `element.click()` inside `browser_evaluate` does not fire jQuery/Vue/MDL handlers.
+- A device input commits on the page's **Done** over a WebSocket, not on the picker's "Update" and not over observable HTTP. Forcing `.checked` or dispatching synthetic events does not persist.
+
+## Verify every mutation
+
+- These UIs fail silently — re-read the DOM or the hub's `configure/json` after every change.
+- `/installedapp/statusJson/<id>` reports device/capability inputs as `None` even when set. Verify device inputs via `/installedapp/configure/json/<id>/<page>` (the `settings` object), or by running the code.
+- `mainPage` and its sub-pages use different table column layouts — identify a column by its hidden `settings[...]` input name or by content, never by index across pages.
+- Screenshots are not visually inspectable in this setup — read state from `browser_snapshot` and DOM reads, not `browser_take_screenshot`.
+
+## Destructive operations
+
+- Read the confirm dialog before an irreversible action (device/app delete, scene edit) and re-verify after.
+- Room Lighting re-captures the current physical state of every scene light on "Done with Room Lights" — an on light silently overwrites the scene. Add members, then set each device's captured state directly (Level cell → `dimLA` input; Switch cell → on/off toggles). Avoid "Re-Capture" unless the physical lights already hold the desired state.
+- Some apps set `removeButton: false` (e.g. HubiThings Replica) and cannot be removed from the UI or a synthetic endpoint — record them as remove-not-automatable.
+- Backups are a proprietary encrypted H2 file, restore-to-hub only (full-hub, all-or-nothing) — a single app's settings cannot be extracted from one.

--- a/rules/ui-automation.md
+++ b/rules/ui-automation.md
@@ -7,7 +7,7 @@ description: Driving the Hubitat web UI with Playwright for UI-only operations â
 
 The `hubitat-dev` toolset is HTTP/code only. A class of operations has no documented endpoint and
 is reachable only through the hub web UI at `http://<hub-ip>:8080`, driven with the Playwright MCP.
-Selectors, setup, the full workflow, and every gotcha's detail live in `reference/playwright-ui.md`.
+The setup, full workflow, selectors, and per-gotcha detail all live in `reference/playwright-ui.md`.
 
 ## Reach for HTTP first
 

--- a/rules/ui-automation.md
+++ b/rules/ui-automation.md
@@ -16,7 +16,7 @@ Selectors, setup, the full workflow, and every gotcha's detail live in `referenc
 
 ## Read state the way the framework stores it
 
-- MDL/Vue checkbox and radio pickers keep selection in a `label.is-checked` CSS class, and leave `input.checked` at `false`. Read the class, never the property — reading `input.checked` once made 15 selected members look unselected and nearly wiped them.
+- MDL/Vue checkbox and radio pickers keep selection in a `label.is-checked` CSS class, and leave `input.checked` at `false`. Read the class, never the property.
 - Act with real `browser_click` / `browser_type`. `element.click()` inside `browser_evaluate` does not fire jQuery/Vue/MDL handlers.
 - A device input commits on the page's **Done** over a WebSocket, not on the picker's "Update" and not over observable HTTP. Forcing `.checked` or dispatching synthetic events does not persist.
 


### PR DESCRIPTION
**Author-Model:** claude-opus-4-8

## Summary
- The `hubitat-dev` toolset is HTTP/code only, but a class of operations is UI-only on a Hubitat hub: installing an app instance, configuring built-in/community apps (Room Lighting, Notifications, CoCoHue, HubiThings Replica), deleting a device or app, importing devices, reading a backup.
- Adds an always-on `rules/ui-automation.md` and `reference/playwright-ui.md` documenting the navigate → snapshot → act → verify workflow for driving the hub UI with the Playwright MCP, plus nine hard-won gotchas — three load-bearing (MDL/Vue `label.is-checked` vs `input.checked`, WebSocket-commit-on-Done persistence, Room Lighting physical-state recapture).
- README rules table + "What it covers" and a CHANGELOG entry updated to match.

Closes #14.

## Test plan
- [x] `tessl plugin lint` passes
- [x] Rule obeys `context-writing-style` (4 H2 sections, ~30 body lines, no banned connectives)
- [x] No scripts/skills changed — pyright/unit-test/skill-review gates unaffected
- [ ] Cross-family policy review (OpenAI) + Copilot green