### PR TITLE
docs(playwright-ui): document 19-zone migration re-point and bulk-UI findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Added
+
+- **Playwright-UI + device-migration findings from a 19-zone migration** (`skills/_reference/playwright-ui.md` 21–23, `skills/device-migration`, closes #43). Follow-up to #41 — a full Zone Motion Controllers → custom-app migration across 19 zones on 2.5.1.131 surfaced findings beyond the picker mechanics. The load-bearing one (22): `mcp__playwright__browser_run_code_unsafe` runs **real** Playwright interactions (`page.locator().click()`, `page.goto`) in a loop inside one tool call — genuine trusted events that persist like `browser_click`, not the synthetic clicks gotcha 4 forbids — collapsing each ~18-call re-point into one, which is the only reason 19 zones were practical; its four caveats (single-arg `page.evaluate`, per-batch picker timeouts, `page.goto` navigation races, stale `page.url()` after a confirm) are captured. Also: Rule Machine trigger devices hide behind Select Trigger Events and RM keeps a stale `tDev-1` beside `tDev1`, so a re-point is verified via `state.trigDevs`, never the raw setting (21); and authoring a device input `required: false` sidesteps #41's empty→filled install trap while the hidden value still persists on Done (23, cross-referenced from 16). `device-migration` gains the `motionsInactive`-vs-`motionsOff` turn-off variant, the "trust the device-level re-read over picker values" rule, the RM `trigDevs` verification (stale `tDev-1` is inert), the two-step PrimeVue app-removal confirm that deletes owned child devices, and the note that agent-initiated deletes are refused by the auto-mode classifier so the user performs them.
+
 ## 0.1.21 — 2026-07-19
 
 ### Added

--- a/skills/_reference/playwright-ui.md
+++ b/skills/_reference/playwright-ui.md
@@ -163,7 +163,8 @@ tools load. The tools used below are the standard Playwright MCP surface: `brows
     cleanly (verified: removed and re-added a member, Done, confirmed via `configure/json`). **For a
     swap, add the new device before removing the old** — the input never goes empty, stays
     `device-btn-filled`, and the trap never fires. This is the biggest limiter here: automated app
-    *install* (empty required input) is unreliable while *edits* are fine (verified 2.5.1.131).
+    *install* (empty required input) is unreliable while *edits* are fine (verified 2.5.1.131). If you
+    author the app, declaring the input `required: false` sidesteps this entirely (gotcha 23).
 
 17. **`is-invalid` on a text input is a red herring.** An MDL text input keeps `class="… is-invalid"`
     on an app that saved fine, and it does not block Done. Do not chase it — in a failed Done the real
@@ -195,16 +196,55 @@ tools load. The tools used below are the standard Playwright MCP surface: `brows
     full baseline from `configure/json` first and diff after: the 457-device edit was verified to change
     exactly `{old}→{new}`, 455 others untouched.
 
+21. **Rule Machine trigger devices hide behind Select Trigger Events, and RM keeps two settings —
+    verify via `state.trigDevs`.** The trigger device is not on the rule's main page: **Select Trigger
+    Events** (`button[name="_action_href_name|selectTriggers|N"]`) → click the existing trigger row (a
+    `<div>` reading e.g. "mZone-X motion reports active") → a `Motion sensors` picker bound to
+    `settings[tDev1]`; swap it like any picker (add-new-before-remove-old, gotcha 16). **RM stores two
+    device settings, `tDev1` and `tDev-1`** — the trigger editor updates only `tDev1`, while `tDev-1` is
+    a staging leftover that keeps pointing at the old device. The authoritative live subscription is
+    **`state.trigDevs`** (e.g. `{"1580:Motion":["1"]}`), with `state.trigDevsW` listing withdrawn
+    devices. Verify a re-point via `state.trigDevs` from the rule's `statusJson`, never the raw `tDev*`
+    setting. Consequence: the stale `tDev-1` makes the old device still show in `hub_device_usage.py`,
+    but that reference is **inert** (no live subscription) — deleting the old device is safe and RM keeps
+    firing on the new one (verified 2.5.1.131).
+
+22. **`browser_run_code_unsafe` runs *real* interactions — batch bulk re-points with it.**
+    `mcp__playwright__browser_run_code_unsafe` runs genuine Playwright calls (`page.locator(sel).click()`,
+    `page.goto`, `page.waitForTimeout`) in a loop inside one tool call. These are **trusted events that
+    persist exactly like `browser_click`** — not the synthetic `element.click()` gotcha 4 forbids. It
+    collapses each ~18-call Room Lights re-point into one call and a 26-toggle Device Activity Check swap
+    into one, which is what made a 19-zone migration practical. Four caveats, each hit for real:
+    - `page.evaluate` takes **one** argument — wrap multiples in an object (`{o,n,t}`), or it errors
+      "Too many arguments".
+    - Picker-open **timeouts** happen (~1 per batch of 5–6 apps) — wrap each item in try/catch, collect
+      results, retry the failure individually.
+    - Batched `page.goto` can **race** a prior page's in-flight navigation → `net::ERR_ABORTED` — retry
+      those with `{waitUntil:'load'}` and longer waits.
+    - `page.url()` reads **stale** right after a confirm-Yes navigation — verify via HTTP
+      (`statusJson`/`fullJson`), not the returned url.
+
+23. **To make an app scriptably installable, author its device inputs `required: false` — it sidesteps
+    gotcha 16.** Gotcha 16's empty→filled trap blocks a scripted install of any app with a *required*
+    device input. An **optional** device input clears Done validation under automation, and the picker's
+    populated hidden-input value still persists on Done even while the button stays `device-btn-empty`
+    (verified: the instance saved all members and created its child device). A member-less instance is
+    then harmless and inert. This does not rescue a third-party app whose input is already required —
+    there it stays gotcha 16 (verified 2.5.1.131).
+
 ## Grounding
 
 Endpoints and hub behavior verified on a C-8 Pro with Hub Security off (baseline
 `skills/_reference/endpoints.md`); gotchas 10–15 verified on 2.5.1.128 while installing a user app instance
 end-to-end (2 device radios, 25 contact-sensor checkboxes across two multi-selects, 5 enum dropdowns,
 Done). Gotchas 16–20 verified on 2.5.1.131 while re-pointing two live apps' device inputs (Room
-Lighting + Device Activity Check) from an old zone device to a new one. Gotchas 1, 2, 5, 10, 16 and 19
-are the load-bearing ones — each was reached the expensive way in real usage; 5 corrupted a live scene,
-10 silently discarded a setting while the page looked correct, 16 blocks automated install of any app
-with a required device input, and 19 switched real lights on.
+Lighting + Device Activity Check) from an old zone device to a new one. Gotchas 21–23 verified on
+2.5.1.131 across a 19-zone Zone Motion Controllers → custom-app migration (Rule Machine trigger
+re-pointing, `browser_run_code_unsafe` batching, `required: false` scriptable install). Gotchas 1, 2, 5,
+10, 16, 19 and 22 are the load-bearing ones — each was reached the expensive way in real usage; 5
+corrupted a live scene, 10 silently discarded a setting while the page looked correct, 16 blocks
+automated install of any app with a required device input, 19 switched real lights on, and 22 is the
+only reason the 19-zone migration was practical.
 
 **Everything here fails silently, which is why 13 is the habit that pays**: a `ref` that clicks a
 container, an Update that never commits, and a working page are indistinguishable on screen. Read the

--- a/skills/device-migration/SKILL.md
+++ b/skills/device-migration/SKILL.md
@@ -125,7 +125,7 @@ it, select the new device where the old was selected, de-select the old, configu
 if the app needs it (every app differs), and hit **Done** — the change does not commit until then,
 and not over observable HTTP (`skills/_reference/playwright-ui.md`).
 
-Four re-point traps, all grounded in `skills/_reference/playwright-ui.md`:
+Re-point traps, all grounded in `skills/_reference/playwright-ui.md`:
 
 - The device input is frequently on a **sub-page**, not the app's main page. Scan for
   `button[name^="_action_href"]` to reach it (gotcha 18) rather than calling a setting unreachable.
@@ -136,18 +136,34 @@ Four re-point traps, all grounded in `skills/_reference/playwright-ui.md`:
   drops the off-screen picks on Update (gotcha 20).
 - In Room Lighting, a `submitOnChange` button on a `settings[...]` id is a **live action**, not
   navigation — "Activate" switches the real lights (gotcha 19).
+- Room Lighting stores the turn-off sensor in **`motionsInactive`** on some instances, not `motionsOff`
+  — a swap of `motions` and `motionsOff` alone misses it silently.
+- Rule Machine hides the trigger device behind **Select Trigger Events** (gotcha 21) and keeps a stale
+  `tDev-1` beside `tDev1`. Verify its re-point via `state.trigDevs` in the rule's `statusJson`, never the
+  raw `tDev*` setting.
 
 Verify each app individually via `/installedapp/configure/json/<appId>/<page>` (the `settings`
 object). Do **not** verify device *inputs* with `/installedapp/statusJson/<appId>` — it reports them as
 `None` even when set (`skills/_reference/endpoints.md`). Its `childDevices` list is a separate, reliable
 field: a managed child device such as `mZone*` is absent from `/hub2/devicesList` top level, and its id
 is read from the parent app's `statusJson.childDevices` (`skills/_reference/parent-child-devices.md`).
-Re-run Step 1's script when done. Proceed to Step 7.
+Trust this device-level re-read over the picker values — it is what catches a turn-off sensor left
+behind in `motionsInactive`. A stale Rule Machine `tDev-1` keeps a re-pointed old device listing the
+rule in Step 1's script, but that reference is **inert** — no live subscription. Once `state.trigDevs`
+shows the new device, the old one is safe to delete. Re-run Step 1's script when done. Proceed to Step 7.
 
 ## Step 7 — Report what moved and what is left
 
 State which apps moved, by what path (swap / bridge / park / manual), and name anything left for the
 user — dashboards, scenes, an app that would not commit, a virtual device still to delete. Never
 report a migration complete on a UI success message alone; report it on the Step 5 re-read.
+
+Removing the **old app** (a superseded zone controller, say) is a two-step PrimeVue confirm — a
+"Remove … now?" prompt, then a "This will remove N child device(s)…" prompt, both `button.p-confirm`
+labelled "Yes" — and it **deletes the app's owned child devices**. A dangling reference from another app does not block
+it: a stale Rule Machine `tDev-1` pointing at a deleted device is inert (`skills/_reference/playwright-ui.md`
+gotcha 21). Agent-initiated Remove/Delete clicks are refused by the auto-mode classifier regardless of
+in-chat approval — the **user performs the destructive delete** (`rules/device-lifecycle.md`), after
+which a fresh retry proceeds.
 
 If the old device is now to be removed, hand off: `Skill(skill: "device-removal")`. Finish here.


### PR DESCRIPTION
**Author-Model:** claude-opus-4-8

## Summary
Captures the grounded findings from issue #43 — a full 19-zone Zone Motion Controllers → custom-app migration on 2.5.1.131 (follow-up to #41).

- `skills/_reference/playwright-ui.md`: gotchas **21–23** — Rule Machine trigger re-pointing (behind Select Trigger Events; RM keeps a stale `tDev-1`; verify via `state.trigDevs`); **`browser_run_code_unsafe`** real-event batching (the load-bearing one — collapses each ~18-call re-point into one; four caveats); and `required: false` scriptable install that sidesteps gotcha 16. Cross-refs 23 from 16; grounding stamp updated.
- `skills/device-migration` Steps 6–7: `motionsInactive`-vs-`motionsOff` turn-off variant, trust-the-device-re-read-over-picker-values, RM `trigDevs` verification (stale `tDev-1` is inert), two-step PrimeVue app-removal confirm (deletes owned child devices), and the auto-mode classifier delete gate.

## Test plan
- [x] `tessl skill review --threshold 85 skills/device-migration/SKILL.md` — PASSED, 93%
- [x] No banned connectives / no 2+-parenthetical sentences in added skill prose
- [x] Removed the brittle "Four re-point traps" count before adding more (the gotcha that cost rounds on #39)
- [x] Imperative title + commit subject (per #42 feedback)
- [x] Closes #43