### PR TITLE
docs(driver-lifecycle): document Virtual Motion Sensor auto-inactive and in-place driver swap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Added
+
+- **The built-in Virtual Motion Sensor auto-inactivates, plus the in-place driver-swap technique** (`rules/driver-lifecycle.md`, `skills/_reference/playwright-ui.md` 24, closes #45). A field finding that broke a live automation: the built-in `hubitat` `Virtual Motion Sensor` `active()` **auto-reverts to `inactive` on a hardcoded ~15s timer**, so an app that drives a virtual motion device to hold aggregated state (a zone controller) drops `inactive` ~15s into a genuinely occupied room and the downstream lighting turns the lights off on the occupant. Verified 2.5.1.131 by commanding `active()` directly from the device page with no app or member sensor involved — `inactive` fired exactly 15s later, and an app-created child device exposes no `autoInactive` preference to disable it; a dead-consistent ~15s active duration in the event history is the signature. `driver-lifecycle` now says to back any app-owned "hold until commanded" device with a trivial custom driver (`capability MotionSensor` + `active`/`inactive` that only `sendEvent`, no timer) and to harden the app to self-heal by re-asserting the intended state on divergence, not only on a transition. Paired with it (gotcha 24): swapping a device's driver in place keeps its id, DNI, and every app reference, so consumers keep working — the mechanics of the 2.5.1.x PrimeVue Type dropdown (`.p-dropdown-label`/`.p-dropdown-filter`/`.p-dropdown-item`, not a native `<select>`), the `installed()`-reset-then-reconcile step, and batching 19 swaps via `browser_run_code_unsafe` are captured.
+
 ## 0.1.23 — 2026-07-19
 
 ### Added

--- a/rules/driver-lifecycle.md
+++ b/rules/driver-lifecycle.md
@@ -26,3 +26,11 @@ A driver is a single Groovy file with a `metadata { definition(...); preferences
 - Z-Wave uses multiple-dispatch `zwaveEvent(...)` overloads with a `hubitat.zwave.Command` catch-all placed **last**.
 - Returning a formatted command string/List from a command method **auto-sends it** to the device — easy to trigger unintentionally. S2 devices wrap with `zwaveSecureEncap(...)`.
 - First line of any protocol `parse()` while developing: `if (logEnable) log.debug "parse: ${description}"` — see `rules/logging-conventions.md`.
+
+## App-driven virtual devices
+
+- The built-in `hubitat` **`Virtual Motion Sensor`** is unsafe for app-driven latched state: its `active()` **auto-reverts to `inactive` on a hardcoded ~15s timer**. An app that drives a virtual motion device to hold an aggregate state, such as a zone controller, cannot keep it `active` with the built-in.
+- Verified 2.5.1.131: a direct `active()` from the device page emitted `inactive` exactly 15s later, and an app-created child device renders no `autoInactive` preference on its edit page to disable it. A dead-consistent ~15s active duration in the event history is the signature.
+- For an app-owned "hold until commanded" device, write a trivial custom driver — `capability "MotionSensor"` plus `active`/`inactive` commands that only `sendEvent`, no timer.
+- Harden the owning app to self-heal: re-assert the device to the intended state whenever it diverges, not only on a transition. An out-of-band command or a hub restart then re-syncs rather than latching.
+- Swap an already-created device onto the custom driver in place — the swap keeps the device id and every app reference (`skills/_reference/playwright-ui.md` gotcha 24).

--- a/skills/_reference/playwright-ui.md
+++ b/skills/_reference/playwright-ui.md
@@ -232,15 +232,28 @@ tools load. The tools used below are the standard Playwright MCP surface: `brows
     then harmless and inert. This does not rescue a third-party app whose input is already required —
     there it stays gotcha 16 (verified 2.5.1.131).
 
+24. **Swap a device's driver in place — it keeps the id, DNI, and every app reference.** Changing an
+    existing device's Type re-points nothing: consumers (Room Lighting, Device Activity Check, Rule
+    Machine) keep working transparently, which makes it the clean fix for a device on the wrong driver
+    (e.g. off the auto-inactivating built-in Virtual Motion Sensor, `rules/driver-lifecycle.md`). On the
+    2.5.1.x PrimeVue device page: `/device/edit/<id>` → **Device Info** tab → the **Type** control is a
+    PrimeVue dropdown (`.p-dropdown-label`, **not** a native `<select>`, so a
+    `querySelectorAll('select')` sweep finds nothing). Click the label to open, type into
+    `.p-dropdown-filter`, click the `.p-dropdown-item` matching the driver name exactly, then page
+    **Save**. The swap re-runs the new driver's `installed()`, so the device's states reset — reconcile
+    the owning app after (its `updated()` re-derives and re-drives). Batches cleanly via
+    `browser_run_code_unsafe` (gotcha 22) — 19 devices swapped this way (verified 2.5.1.131).
+
 ## Grounding
 
 Endpoints and hub behavior verified on a C-8 Pro with Hub Security off (baseline
 `skills/_reference/endpoints.md`); gotchas 10–15 verified on 2.5.1.128 while installing a user app instance
 end-to-end (2 device radios, 25 contact-sensor checkboxes across two multi-selects, 5 enum dropdowns,
 Done). Gotchas 16–20 verified on 2.5.1.131 while re-pointing two live apps' device inputs (Room
-Lighting + Device Activity Check) from an old zone device to a new one. Gotchas 21–23 verified on
+Lighting + Device Activity Check) from an old zone device to a new one. Gotchas 21–24 verified on
 2.5.1.131 across a 19-zone Zone Motion Controllers → custom-app migration (Rule Machine trigger
-re-pointing, `browser_run_code_unsafe` batching, `required: false` scriptable install). Gotchas 1, 2, 5,
+re-pointing, `browser_run_code_unsafe` batching, `required: false` scriptable install, in-place driver
+swap). Gotchas 1, 2, 5,
 10, 16, 19 and 22 are the load-bearing ones — each was reached the expensive way in real usage; 5
 corrupted a live scene, 10 silently discarded a setting while the page looked correct, 16 blocks
 automated install of any app with a required device input, 19 switched real lights on, and 22 is the


### PR DESCRIPTION
**Author-Model:** claude-opus-4-8

## Summary
Captures issue #45 — a field finding that broke a live automation (follow-up to #41/#43).

- `rules/driver-lifecycle.md`: new **App-driven virtual devices** section — the built-in `hubitat` `Virtual Motion Sensor` `active()` auto-reverts to `inactive` on a hardcoded ~15s timer, so it can't hold an app-driven latched state (a zone aggregate); back such a device with a trivial custom `MotionSensor` driver (no timer) and harden the app to self-heal (re-assert on divergence, not only on transition). Verified 2.5.1.131.
- `skills/_reference/playwright-ui.md`: gotcha **24** — swapping a device's driver in place keeps its id/DNI/every app reference; PrimeVue Type-dropdown mechanics, `installed()`-reset-then-reconcile, `browser_run_code_unsafe` batching (19 swaps).

## Test plan
- [x] No banned connectives / no 2+-parenthetical sentences in the rule addition (`active()` function-notation exempt; rephrased the one appositive to be unambiguous)
- [x] `driver-lifecycle` stays within the 3–6 H2 section budget (4)
- [x] Reference-file gotcha matches the file's voice + grounding-stamp convention
- [x] Imperative title + commit subject
- [x] Closes #45