### PR TITLE
docs(app-lifecycle): guard state.* in handlers that skip initialize()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Added
+
+- **`hubStartupHandler()` skips `initialize()` — guard `state.*` or it NPEs on boot** (`rules/app-lifecycle.md`, closes #47). A shipped-app failure surfaced by Error Monitor: `java.lang.NullPointerException: cannot invoke method keySet() on null object (hubStartupHandler)`. The app set up its state maps in `initialize()`, but `hubStartupHandler()` runs on hub startup **without** routing through `installed()`/`updated()`/`initialize()`, so on a boot where the map was still null a shared `reconcile()` reading `state.activeSince.keySet()` blew up. The same trap catches any entry point the platform can invoke before the first Done or after a state reset — a subscribed event, a scheduled job. `app-lifecycle` gains a "Handlers that skip initialize()" section next to the reinitialize idiom: put state-map setup in a small `ensureState()` helper called from every entry point that reads it (or null-guard at the read site), and test it with a spec that drives the startup path on a never-initialized instance and asserts no NPE — it fails before the guard, passes after.
+
 ## 0.1.24 — 2026-07-19
 
 ### Added

--- a/rules/app-lifecycle.md
+++ b/rules/app-lifecycle.md
@@ -30,9 +30,9 @@ def initialize(){ subscribe(motionSensor, "motion", "motionHandler") }
 
 ## Handlers that skip initialize()
 
-- `hubStartupHandler()` runs on hub startup **without** routing through `installed()`/`updated()`/`initialize()`. Any `state.*` map that `initialize()` sets up may be null when it fires, and reading it NPEs on boot (`cannot invoke method keySet() on null object`).
+- `hubStartupHandler()` runs on hub startup **without** routing through `installed()`/`updated()`/`initialize()`. Any `state.*` value that `initialize()` sets up may be null when it fires, and reading it NPEs on boot (`cannot invoke method keySet() on null object`).
 - The same trap catches any entry point the platform invokes before the first **Done** or after a state reset — `hubStartupHandler`, a subscribed event, a scheduled job.
-- Do not initialize state maps in `initialize()` alone. Put the setup in a small helper, call it from **every** entry point that reads that state, or null-guard at the read site (`rules/groovy-gotchas.md`).
+- Do not initialize `state.*` collections in `initialize()` alone — a Map and a List both start null (the example seeds each). Put the setup in a small helper, call it from **every** entry point that reads them, or null-guard at the read site (`rules/groovy-gotchas.md`).
 
 ```groovy
 private ensureState() {
@@ -44,7 +44,7 @@ private reconcile()     { ensureState(); /* reached from hubStartupHandler(), wh
 def hubStartupHandler() { reconcile() }
 ```
 
-- Test it: a spec that drives the startup/handler path on a freshly-loaded, **never-initialized** instance and asserts no NPE catches this deterministically — it fails before the guard, passes after (`rules/testing-standards.md`).
+- Test it: a spec that drives the startup/handler path on a freshly-loaded, **never-initialized** instance and asserts no NPE catches this deterministically — it fails before the guard, passes after (`skills/test`).
 
 ## Subscriptions & scheduling
 

--- a/rules/app-lifecycle.md
+++ b/rules/app-lifecycle.md
@@ -28,6 +28,24 @@ def initialize(){ subscribe(motionSensor, "motion", "motionHandler") }
 
 - `unsubscribe()` at the top of `updated()`/`initialize()` prevents duplicate subscriptions when the user changes a selected device. The same applies to schedules — `unschedule()` before re-scheduling, or `runIn`/`schedule` stack silently unless `overwrite` is left at its default.
 
+## Handlers that skip initialize()
+
+- `hubStartupHandler()` runs on hub startup **without** routing through `installed()`/`updated()`/`initialize()`. Any `state.*` map that `initialize()` sets up may be null when it fires, and reading it NPEs on boot (`cannot invoke method keySet() on null object`).
+- The same trap catches any entry point the platform invokes before the first **Done** or after a state reset — `hubStartupHandler`, a subscribed event, a scheduled job.
+- Do not initialize state maps in `initialize()` alone. Put the setup in a small helper, call it from **every** entry point that reads that state, or null-guard at the read site (`rules/groovy-gotchas.md`).
+
+```groovy
+private ensureState() {
+    if (state.activeSince == null) state.activeSince = [:]
+    if (state.stuck == null)       state.stuck = []
+}
+def initialize()        { ensureState(); /* subscribe … */ }
+private reconcile()     { ensureState(); /* reached from hubStartupHandler(), which skips initialize() */ }
+def hubStartupHandler() { reconcile() }
+```
+
+- Test it: a spec that drives the startup/handler path on a freshly-loaded, **never-initialized** instance and asserts no NPE catches this deterministically — it fails before the guard, passes after (`rules/testing-standards.md`).
+
 ## Subscriptions & scheduling
 
 - Handler method names are passed as **bare strings**: `subscribe(dev, "switch", "switchHandler")`, `runIn(300, "checkState")`. A typo'd or missing handler name fails quietly — see `rules/groovy-gotchas.md`.


### PR DESCRIPTION
**Author-Model:** claude-opus-4-8

## Summary
Captures issue #47 — a shipped-app boot NPE (`cannot invoke method keySet() on null object` in `hubStartupHandler`).

- `rules/app-lifecycle.md`: new **Handlers that skip initialize()** section next to the reinitialize idiom. `hubStartupHandler()` (and any handler that fires before the first `installed()`/`updated()` or after a state reset) does not run `initialize()`, so `state.*` maps it reads can be null → NPE on boot. Guidance: put state-map setup in an `ensureState()` helper called from every entry point (or null-guard at the read site), and test the never-initialized startup path with a spec that asserts no NPE.

## Test plan
- [x] No banned connectives / no 2+-parenthetical sentences in the rule addition
- [x] `app-lifecycle` stays within the 3–6 H2 section budget (4)
- [x] Imperative title + commit subject
- [x] Closes #47