### PR TITLE
docs(playwright-ui): add optional-input hidden-value shortcut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Added
+
+- **Skip the picker for an *optional* device input — write the hidden value and let Done serialize it** (`skills/_reference/playwright-ui.md` 14, `rules/ui-automation.md`, closes #51). From wiring 15 app instances' optional `capability.switch` plug inputs (`plug_<id>` on Zone Motion Watchdog) via the Playwright MCP on 2.5.1.131: the app config page's **Done** button (`button[name="_action_update"]`) serializes the form's hidden `input[name="settings[<name>]"]` values over the websocket, so an optional device input needs no picker at all — set the hidden input's `.value` to the id list in `browser_evaluate`, click Done, and it persists. Collapses each input from ~9 tool calls to ~3. It is **not** the gotcha 2/4 synthetic-event trap: you write the real commit-signal field (gotcha 13), the exact value the picker's own Update writes and Done reads. Scope limit — **optional inputs only**: a `required: true` input still validates on Done via `device-btn-empty` (gotcha 17), which this does not flip, so a required-empty input stays rejected (the #41 empty→filled trap) — use the real picker there, or edit an already-filled one. Verified 2.5.1.131 across 14 single-plug zones: the value survives Done in `configure/json` and every other hidden `settings[*]` stays untouched. The new gotcha 14 lands right after gotcha 13 (its direct consequence), renumbering the former 14–24 to 15–25.
+
 ## 0.1.25 — 2026-07-20
 
 ### Added

--- a/rules/driver-lifecycle.md
+++ b/rules/driver-lifecycle.md
@@ -33,4 +33,4 @@ A driver is a single Groovy file with a `metadata { definition(...); preferences
 - Verified 2.5.1.131: a direct `active()` from the device page emitted `inactive` exactly 15s later, and an app-created child device renders no `autoInactive` preference on its edit page to disable it. A dead-consistent ~15s active duration in the event history is the signature.
 - For an app-owned "hold until commanded" device, write a trivial custom driver — `capability "MotionSensor"` plus `active`/`inactive` commands that only `sendEvent`, no timer.
 - Harden the owning app to self-heal: re-assert the device to the intended state whenever it diverges, not only on a transition. An out-of-band command or a hub restart then re-syncs rather than latching.
-- Swap an already-created device onto the custom driver in place — the swap keeps the device id and every app reference (`skills/_reference/playwright-ui.md` gotcha 24).
+- Swap an already-created device onto the custom driver in place — the swap keeps the device id and every app reference (`skills/_reference/playwright-ui.md` gotcha 25).

--- a/rules/ui-automation.md
+++ b/rules/ui-automation.md
@@ -20,6 +20,7 @@ The setup, full workflow, selectors, and per-gotcha detail all live in `skills/_
 - Act with real `browser_click` / `browser_type`. `element.click()` inside `browser_evaluate` does not fire jQuery/Vue/MDL handlers.
 - Snapshot `ref`s are unreliable on Hubitat's MDL `<div>` controls — a `ref` resolves to a wrapper and the click hits a container, silently. Tag the real control by walking up from its hidden `settings[...]` input, then click the tag: `skills/_reference/playwright-ui.md` gotchas 10–12. Tagging in `browser_evaluate` is not the banned synthetic click.
 - A device input persists to the hub on the page's **Done** over a WebSocket, not over observable HTTP. Forcing `.checked` or dispatching synthetic events does not persist.
+- An **optional** device input needs no picker — set its hidden `settings[<name>]` value directly and Done serializes it; the empty→filled validation only gates **required** inputs (`skills/_reference/playwright-ui.md` gotcha 14).
 - Commit device inputs **before** filling the sections a `submitOnChange` gates — the dependent controls do not exist until the picker's Update commits.
 
 ## Verify every mutation

--- a/rules/ui-automation.md
+++ b/rules/ui-automation.md
@@ -20,7 +20,7 @@ The setup, full workflow, selectors, and per-gotcha detail all live in `skills/_
 - Act with real `browser_click` / `browser_type`. `element.click()` inside `browser_evaluate` does not fire jQuery/Vue/MDL handlers.
 - Snapshot `ref`s are unreliable on Hubitat's MDL `<div>` controls — a `ref` resolves to a wrapper and the click hits a container, silently. Tag the real control by walking up from its hidden `settings[...]` input, then click the tag: `skills/_reference/playwright-ui.md` gotchas 10–12. Tagging in `browser_evaluate` is not the banned synthetic click.
 - A device input persists to the hub on the page's **Done** over a WebSocket, not over observable HTTP. Forcing `.checked` or dispatching synthetic events does not persist.
-- An **optional** device input needs no picker — set its hidden `settings[<name>]` value directly and Done serializes it; the empty→filled validation only gates **required** inputs (`skills/_reference/playwright-ui.md` gotcha 14).
+- An **optional** device input needs no picker — set its hidden `settings[<name>]` value directly and Done serializes it; the empty→filled validation only gates **required** inputs (`skills/_reference/playwright-ui.md` gotcha 14; the required-input validation trap is gotcha 17).
 - Commit device inputs **before** filling the sections a `submitOnChange` gates — the dependent controls do not exist until the picker's Update commits.
 
 ## Verify every mutation

--- a/skills/_reference/playwright-ui.md
+++ b/skills/_reference/playwright-ui.md
@@ -138,7 +138,28 @@ tools load. The tools used below are the standard Playwright MCP surface: `brows
     comma-separated id list after (`"35,33,26,21,…"`). Cheapest possible check, and it catches
     gotcha 10 immediately. `.value` order is **selection order, not sorted** — compare as a set.
 
-14. **`submitOnChange` device inputs gate the sections below them.** A device input with
+14. **For an *optional* device input, skip the picker — write the hidden `settings[<name>]` value and let Done serialize it.**
+    Done (`button[name="_action_update"]`) serializes the form's hidden `input[name="settings[<name>]"]`
+    values over the websocket, so an optional device input needs no picker: set the hidden input's
+    `.value` to the device id (comma-separated for multi-select — the same string the picker writes) in
+    `browser_evaluate`, then a real `browser_click` on Done. This is **not** the synthetic-event trap
+    (gotchas 2, 4): you write the real commit-signal field (gotcha 13), the exact value the picker's own
+    Update writes and Done reads — not a faked event on an option.
+
+    ```js
+    // browser_evaluate — set the commit signal directly, then tag Done for a real click
+    document.querySelector('input[name="settings[plug_565]"]').value = "1246"; // id list
+    document.querySelector('button[name="_action_update"]').id = 'claude-done';
+    // then: browser_click(target: '#claude-done')
+    ```
+    Collapses each optional-input wiring from ~9 tool calls to ~3 (navigate → one evaluate → one Done
+    click). **Optional only**: a `required: true` input still validates on Done via `device-btn-empty`
+    (gotcha 17), which this does not flip — a required-empty input stays rejected, so use the real picker
+    to reach `device-btn-filled` (or edit an already-filled one). Verify at the source, never the UI:
+    after Done, `configure/json/<appId>/<page>` shows `settings[plug_565] = {"1246":"<label>"}` and every
+    other hidden `settings[*]` untouched (verified 2.5.1.131, 14 single-plug zones).
+
+15. **`submitOnChange` device inputs gate the sections below them.** A device input with
     `submitOnChange: true` re-renders its dependent sections only **after its picker's Update
     commits** — not when the option is clicked. Dropdowns built from the selected device's data do
     not exist before then, so there is nothing to `selectOption`. **Order matters: commit the device
@@ -146,7 +167,7 @@ tools load. The tools used below are the standard Playwright MCP surface: `brows
     later `submitOnChange` re-render (verified: five dropdown values intact after a second device
     picker committed).
 
-15. **Opening an app config page creates a transient instance — protect it with a second tab.**
+16. **Opening an app config page creates a transient instance — protect it with a second tab.**
     Opening a user app from **Add user app** lands on `/installedapp/configure/<newId>/mainPage` with
     a real id, but nothing persists until **Done**, and the form carries `_cancellable: false`.
     **Never navigate the configuring tab.** To touch another app mid-configuration, open a second tab
@@ -154,7 +175,7 @@ tools load. The tools used below are the standard Playwright MCP surface: `brows
     Config survived the tab switch intact (verified 2.5.1.128). Same family as the built-in app's
     transient instance discarded on Cancel (`skills/_reference/endpoints.md`, `/installedapp/direct/`).
 
-16. **A fresh *required* device input will not commit via automation — the empty→filled transition
+17. **A fresh *required* device input will not commit via automation — the empty→filled transition
     fails silently.** The picker mechanism (gotchas 10–13) works for **edits** but not for a first
     fill. An empty required picker starts `device-btn-empty`; after checking devices and clicking
     Update, the hidden `input[name="settings[<name>]"]` **does** take the id list (gotcha 13's commit
@@ -164,14 +185,14 @@ tools load. The tools used below are the standard Playwright MCP surface: `brows
     swap, add the new device before removing the old** — the input never goes empty, stays
     `device-btn-filled`, and the trap never fires. This is the biggest limiter here: automated app
     *install* (empty required input) is unreliable while *edits* are fine (verified 2.5.1.131). If you
-    author the app, declaring the input `required: false` sidesteps this entirely (gotcha 23).
+    author the app, declaring the input `required: false` sidesteps this entirely (gotcha 24).
 
-17. **`is-invalid` on a text input is a red herring.** An MDL text input keeps `class="… is-invalid"`
+18. **`is-invalid` on a text input is a red herring.** An MDL text input keeps `class="… is-invalid"`
     on an app that saved fine, and it does not block Done. Do not chase it — in a failed Done the real
-    blocker is gotcha 16's `device-btn-empty`, not a text field's `is-invalid` (cost real time treating
+    blocker is gotcha 17's `device-btn-empty`, not a text field's `is-invalid` (cost real time treating
     it as the blocker).
 
-18. **Device inputs are often on sub-pages reached by `hrefElem` buttons, not `<a>` links.** The target
+19. **Device inputs are often on sub-pages reached by `hrefElem` buttons, not `<a>` links.** The target
     input is frequently not on the app's main page. Scan for `button[name^="_action_href"]` to discover
     sub-pages instead of concluding a setting is unreachable. Room Lighting:
     `button[name="_action_href_name|onMeansPage|N"]` → `motions`; `…|offMeansPage|N` → `motionsOff`.
@@ -179,7 +200,7 @@ tools load. The tools used below are the standard Playwright MCP surface: `brows
     `group1.devices`. Return via `_action_previous` ("Done with …") or `_action_next` (`id=btnNext`);
     final commit is the main-page `_action_update` (`id=btnDone`).
 
-19. **Room Lighting has live-trigger buttons that look like navigation — they have side effects.**
+20. **Room Lighting has live-trigger buttons that look like navigation — they have side effects.**
     The buttons with id `settings[activate]` ("Activate") and `settings[turnOff]` ("Turn Off") are
     `submitOnChange` buttons that **physically switch the room's lights** and flip the page title to
     "(Active)". Target them as `button[id="settings[activate]"]` — the bracketed id is not a CSS
@@ -188,7 +209,7 @@ tools load. The tools used below are the standard Playwright MCP surface: `brows
     navigation (safe); a `submitOnChange` on a `settings[...]`-id button is a **live action**. Read the
     class and name before clicking any unfamiliar Room Lighting button.
 
-20. **Large pickers: gate on virtualization before toggling.** One monitored-device input held 457
+21. **Large pickers: gate on virtualization before toggling.** One monitored-device input held 457
     devices. Before editing, open the picker and compare the rendered `label.is-checked` count to the
     known selection count. 481 checkboxes rendered with exactly 457 checked ⇒ the full set is in the
     DOM, not virtualized ⇒ Update reads all of it and toggling two is safe. If fewer render than are
@@ -196,11 +217,11 @@ tools load. The tools used below are the standard Playwright MCP surface: `brows
     full baseline from `configure/json` first and diff after: the 457-device edit was verified to change
     exactly `{old}→{new}`, 455 others untouched.
 
-21. **Rule Machine trigger devices hide behind Select Trigger Events, and RM keeps two settings —
+22. **Rule Machine trigger devices hide behind Select Trigger Events, and RM keeps two settings —
     verify via `state.trigDevs`.** The trigger device is not on the rule's main page: **Select Trigger
     Events** (`button[name="_action_href_name|selectTriggers|N"]`) → click the existing trigger row (a
     `<div>` reading e.g. "mZone-X motion reports active") → a `Motion sensors` picker bound to
-    `settings[tDev1]`; swap it like any picker (add-new-before-remove-old, gotcha 16). **RM stores two
+    `settings[tDev1]`; swap it like any picker (add-new-before-remove-old, gotcha 17). **RM stores two
     device settings, `tDev1` and `tDev-1`** — the trigger editor updates only `tDev1`, while `tDev-1` is
     a staging leftover that keeps pointing at the old device. The authoritative live subscription is
     **`state.trigDevs`** (e.g. `{"1580:Motion":["1"]}`), with `state.trigDevsW` listing withdrawn
@@ -209,7 +230,7 @@ tools load. The tools used below are the standard Playwright MCP surface: `brows
     but that reference is **inert** (no live subscription) — deleting the old device is safe and RM keeps
     firing on the new one (verified 2.5.1.131).
 
-22. **`browser_run_code_unsafe` runs *real* interactions — batch bulk re-points with it.**
+23. **`browser_run_code_unsafe` runs *real* interactions — batch bulk re-points with it.**
     `mcp__playwright__browser_run_code_unsafe` runs genuine Playwright calls (`page.locator(sel).click()`,
     `page.goto`, `page.waitForTimeout`) in a loop inside one tool call. These are **trusted events that
     persist exactly like `browser_click`** — not the synthetic `element.click()` gotcha 4 forbids. It
@@ -224,15 +245,15 @@ tools load. The tools used below are the standard Playwright MCP surface: `brows
     - `page.url()` reads **stale** right after a confirm-Yes navigation — verify via HTTP
       (`statusJson`/`fullJson`), not the returned url.
 
-23. **To make an app scriptably installable, author its device inputs `required: false` — it sidesteps
-    gotcha 16.** Gotcha 16's empty→filled trap blocks a scripted install of any app with a *required*
+24. **To make an app scriptably installable, author its device inputs `required: false` — it sidesteps
+    gotcha 17.** Gotcha 17's empty→filled trap blocks a scripted install of any app with a *required*
     device input. An **optional** device input clears Done validation under automation, and the picker's
     populated hidden-input value still persists on Done even while the button stays `device-btn-empty`
     (verified: the instance saved all members and created its child device). A member-less instance is
     then harmless and inert. This does not rescue a third-party app whose input is already required —
-    there it stays gotcha 16 (verified 2.5.1.131).
+    there it stays gotcha 17 (verified 2.5.1.131).
 
-24. **Swap a device's driver in place — it keeps the id, DNI, and every app reference.** Changing an
+25. **Swap a device's driver in place — it keeps the id, DNI, and every app reference.** Changing an
     existing device's Type re-points nothing: consumers (Room Lighting, Device Activity Check, Rule
     Machine) keep working transparently, which makes it the clean fix for a device on the wrong driver
     (e.g. off the auto-inactivating built-in Virtual Motion Sensor, `rules/driver-lifecycle.md`). On the
@@ -242,21 +263,22 @@ tools load. The tools used below are the standard Playwright MCP surface: `brows
     `.p-dropdown-filter`, click the `.p-dropdown-item` matching the driver name exactly, then page
     **Save**. The swap re-runs the new driver's `installed()`, so the device's states reset — reconcile
     the owning app after (its `updated()` re-derives and re-drives). Batches cleanly via
-    `browser_run_code_unsafe` (gotcha 22) — 19 devices swapped this way (verified 2.5.1.131).
+    `browser_run_code_unsafe` (gotcha 23) — 19 devices swapped this way (verified 2.5.1.131).
 
 ## Grounding
 
 Endpoints and hub behavior verified on a C-8 Pro with Hub Security off (baseline
-`skills/_reference/endpoints.md`); gotchas 10–15 verified on 2.5.1.128 while installing a user app instance
+`skills/_reference/endpoints.md`); gotchas 10–13 and 15–16 verified on 2.5.1.128 while installing a user app instance
 end-to-end (2 device radios, 25 contact-sensor checkboxes across two multi-selects, 5 enum dropdowns,
-Done). Gotchas 16–20 verified on 2.5.1.131 while re-pointing two live apps' device inputs (Room
-Lighting + Device Activity Check) from an old zone device to a new one. Gotchas 21–24 verified on
+Done). Gotchas 17–21 verified on 2.5.1.131 while re-pointing two live apps' device inputs (Room
+Lighting + Device Activity Check) from an old zone device to a new one. Gotchas 22–25 verified on
 2.5.1.131 across a 19-zone Zone Motion Controllers → custom-app migration (Rule Machine trigger
 re-pointing, `browser_run_code_unsafe` batching, `required: false` scriptable install, in-place driver
-swap). Gotchas 1, 2, 5,
-10, 16, 19 and 22 are the load-bearing ones — each was reached the expensive way in real usage; 5
-corrupted a live scene, 10 silently discarded a setting while the page looked correct, 16 blocks
-automated install of any app with a required device input, 19 switched real lights on, and 22 is the
+swap). Gotcha 14 verified on 2.5.1.131 while wiring 15 app instances' optional plug inputs on Zone
+Motion Watchdog (14 single-plug zones, hidden value + Done, no picker). Gotchas 1, 2, 5,
+10, 17, 20 and 23 are the load-bearing ones — each was reached the expensive way in real usage; 5
+corrupted a live scene, 10 silently discarded a setting while the page looked correct, 17 blocks
+automated install of any app with a required device input, 20 switched real lights on, and 23 is the
 only reason the 19-zone migration was practical.
 
 **Everything here fails silently, which is why 13 is the habit that pays**: a `ref` that clicks a

--- a/skills/_reference/playwright-ui.md
+++ b/skills/_reference/playwright-ui.md
@@ -147,10 +147,9 @@ tools load. The tools used below are the standard Playwright MCP surface: `brows
     Update writes and Done reads — not a faked event on an option.
 
     ```js
-    // browser_evaluate — set the commit signal directly, then tag Done for a real click
+    // browser_evaluate — set the commit signal directly; Done already has a stable selector
     document.querySelector('input[name="settings[plug_565]"]').value = "1246"; // id list
-    document.querySelector('button[name="_action_update"]').id = 'claude-done';
-    // then: browser_click(target: '#claude-done')
+    // then: browser_click(target: 'button[name="_action_update"]')   <- real click on Done (id=btnDone)
     ```
     Collapses each optional-input wiring from ~9 tool calls to ~3 (navigate → one evaluate → one Done
     click). **Optional only**: a `required: true` input still validates on Done via `device-btn-empty`

--- a/skills/device-migration/SKILL.md
+++ b/skills/device-migration/SKILL.md
@@ -128,17 +128,17 @@ and not over observable HTTP (`skills/_reference/playwright-ui.md`).
 Re-point traps, all grounded in `skills/_reference/playwright-ui.md`:
 
 - The device input is frequently on a **sub-page**, not the app's main page. Scan for
-  `button[name^="_action_href"]` to reach it (gotcha 18) rather than calling a setting unreachable.
+  `button[name^="_action_href"]` to reach it (gotcha 19) rather than calling a setting unreachable.
 - **Add the new device before removing the old.** A required input taken empty will not re-commit via
-  automation, and Done then rejects the page as incomplete (gotcha 16). Keeping it populated dodges the
+  automation, and Done then rejects the page as incomplete (gotcha 17). Keeping it populated dodges the
   trap.
 - Before toggling a **large** multi-select, confirm the full selection renders — a virtualized list
-  drops the off-screen picks on Update (gotcha 20).
+  drops the off-screen picks on Update (gotcha 21).
 - In Room Lighting, a `submitOnChange` button on a `settings[...]` id is a **live action**, not
-  navigation — "Activate" switches the real lights (gotcha 19).
+  navigation — "Activate" switches the real lights (gotcha 20).
 - Room Lighting stores the turn-off sensor in **`motionsInactive`** on some instances, not `motionsOff`
   — a swap of `motions` and `motionsOff` alone misses it silently.
-- Rule Machine hides the trigger device behind **Select Trigger Events** (gotcha 21) and keeps a stale
+- Rule Machine hides the trigger device behind **Select Trigger Events** (gotcha 22) and keeps a stale
   `tDev-1` beside `tDev1`. Verify its re-point via `state.trigDevs` in the rule's `statusJson`, never the
   raw `tDev*` setting.
 
@@ -162,7 +162,7 @@ Removing the **old app** (a superseded zone controller, say) is a two-step Prime
 "Remove … now?" prompt, then a "This will remove N child device(s)…" prompt, both `button.p-confirm`
 labelled "Yes" — and it **deletes the app's owned child devices**. A dangling reference from another app does not block
 it: a stale Rule Machine `tDev-1` pointing at a deleted device is inert (`skills/_reference/playwright-ui.md`
-gotcha 21). Agent-initiated Remove/Delete clicks are refused by the auto-mode classifier regardless of
+gotcha 22). Agent-initiated Remove/Delete clicks are refused by the auto-mode classifier regardless of
 in-chat approval — the **user performs the destructive delete** (`rules/device-lifecycle.md`), after
 which a fresh retry proceeds.
 


### PR DESCRIPTION
Closes #51.

## What

Documents a verified Playwright-MCP shortcut for **optional** device inputs: the app config page's **Done** button (`button[name="_action_update"]`) serializes the form's hidden `input[name="settings[<name>]"]` values over the websocket, so an optional device input needs no picker — set the hidden input's `.value` in `browser_evaluate`, click Done, and it persists. Collapses each input from ~9 tool calls to ~3.

## Placement

New **gotcha 14** in `skills/_reference/playwright-ui.md`, right after gotcha 13 (the hidden input is the commit signal) — its direct consequence, exactly where issue #51 proposed it. The former gotchas 14–24 renumber to 15–25; every by-number cross-reference and the Grounding section are updated to match.

## Scope guard

Optional inputs only. A `required: true` input still validates on Done via `device-btn-empty` (gotcha 17), which this does not flip, so a required-empty input stays rejected (the #41 empty→filled trap) — use the real picker there, or edit an already-filled one. This is **not** the gotcha 2/4 synthetic-event trap: you write the real commit-signal field the picker's own Update writes and Done reads.

## Also

- Terse pointer added to `rules/ui-automation.md`.
- CHANGELOG un-headed `### Added` block (stamp step supplies the version heading on publish).

Verified 2.5.1.131 across 14 single-plug zones: value survives Done in `configure/json`, every other hidden `settings[*]` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEwgH2X2fVTLvzV8UW5qoS