### PR TITLE
Add firmware-update skill: safe Z-Wave OTA batch-flasher (native zwaveJS updater)

### DIFF
--- a/.tessl-plugin/plugin.json
+++ b/.tessl-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jbaruch/hubitat-dev",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "description": "Context for developing and debugging Hubitat Elevation apps, drivers, and hub environment — sandbox constraints, lifecycle idioms, capability contracts, plus grounded deploy/log-tail/lint mechanisms.",
   "private": false,
   "rules": "rules/",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.38 — 2026-07-22
+
+### Added
+
+- **Firmware-update skill: safe Z-Wave OTA batch-flashing** (`rules/firmware-update.md`, `skills/firmware-update/SKILL.md`, `skills/_scripts/hub_fw_update.py`, closes #64). Grounded live on 2.5.1.132 (C-8 Pro, zwaveJS) flashing ~67 Zooz/Leviton devices across two hubs. Uses the hub's **native** Device firmware updater (`/hub/zwave/deviceFirmware/{files,details,available,start,progress}` + `/hub/fileManager/upload/firmware`) — flashes **in place** over LR+S2 with no driver swap; the community driver-swap updaters stall on LR/S2 ("Please wake up your sleepy device" on a *mains* device = wrong tool). The load-bearing finding, learned twice the hard way: a **failed OR stalled** OTA hangs the **entire** zwaveJS controller — the hub returns `success:true` but transmits nothing, freezing every Z-Wave node at once while **Zigbee stays up** (the diagnostic tell), the Hub-Mesh peer still reads `active/reachable`, and downstream it **staleness-poisons every lux/temperature-gated automation** (a "Motion at Dark" rule fired lights in daylight off a frozen illuminance sensor). A big fleet hides it (successes after a failure re-kick the radio); the trailing/only failure is the dangerous one. `hub_fw_update.py` carries the guards, **all required** (a canary-only guard *missed* a mid-transfer stall): a **no-progress watchdog** (abort if `percent` stops advancing at ANY level, not just 0%), a **canary** radio-health probe between flashes that **reboots + re-checks** on a hang, and an **RSSI floor** (default −95 dBm) that skips hang-prone floor-signal nodes (`--flash-weak` to force, attended only) — plus idempotent skip, a circuit breaker, and `--wait-pid` to chain one radio. `SKILL.md` walks discover (`/device/fullJson` → `device.data.firmwareVersion`) → **vendor-latest, NOT auto-discovery** (the Z-Wave JS service lagged ZEN04 2.30 vs shipped 2.60, missing the 2.50 SDK 7.19→7.24 S2/SPAN fix, and offered a Springs shade a bogus downgrade) → hardware-revision-correct image (700 vs 800LR) → stage (upload once per model, reusable) → flash → verify (hub caches the old version until the post-reboot re-interview). Recovery: `getManagementToken` → `/management/reboot` clears the hang; nothing bricks (`nodeState OK`), a stalled node sometimes completes post-reboot.
+
 ## 0.1.37 — 2026-07-22
 
 ### Added

--- a/rules/firmware-update.md
+++ b/rules/firmware-update.md
@@ -1,0 +1,51 @@
+---
+alwaysApply: true
+description: Z-Wave device firmware (OTA) updates on Hubitat — a failed OR stalled flash can hang the whole controller; prerequisites, vendor-latest sourcing, and the mandatory watchdog/canary/RSSI-floor guardrails
+---
+
+# Z-Wave Firmware Updates
+
+Updating device firmware is one of the few genuinely dangerous operations on a hub: a bad flash is closer to a brick than a `git revert`, and — the trap that surprised us — a flash that merely **stalls** can take the whole radio down with it. Flash deliberately, one radio at a time, guarded.
+
+## Use the hub's native zwaveJS updater, not a driver swap
+
+- Settings → Z-Wave Details → Maintenance → **Device firmware updater** (UI page `/hub/zwaveInfo`) flashes OTA over the radio the device already uses. It handles **Long Range + S2**; the community driver-swap updaters (swap to a firmware-updater driver, call `updateFirmware(url)`) **stall on LR/S2** ("Please wake up your sleepy device" on a mains device = wrong tool, not "wait longer").
+- HTTP surface (no auth, Hub Security off): `POST /hub/fileManager/upload/firmware` (multipart), `GET /hub/zwave/deviceFirmware/files`, `GET …/details?nodeId=N`, `POST …/start {nodeId,target:0,fileName}`, `GET …/progress?nodeId=N` → `{progress:{percent,stage}}` (`PROCESS`→`SENDING`→`DONE`). It flashes **in place** — no driver change, the device keeps its real driver. `skills/_scripts/hub_fw_update.py` drives it; `skills/firmware-update/SKILL.md` is the procedure.
+
+## Prerequisites (check before flashing)
+
+- **Backend is zwaveJS** (`zwaveJS:true` in `/hub/zwaveDetails/json`). This skill/API is the zwaveJS updater.
+- **Right image for the hardware revision.** 700-series and 800LR share a model name but need **different** files — pick by the installed major version (ZEN76 3.x → 3.60 / 800LR; 2.x/10.x → 700-series). The wrong image bricks; the hub rejects a mismatch at `/start`, but do not rely on that.
+- **Mains vs battery/FLiRS.** Mains devices flash unattended. Battery/sleepy devices (locks, most sensors) must be **awake** for the multi-minute transfer — USB power, fresh batteries, or operate them to wake (a lock via lock/unlock, a motion sensor via motion). A lock also has a *second* firmware plane (main/Wi-Fi over Bluetooth in the vendor app) distinct from the Z-Wave module image the hub flashes.
+- **One batch per radio.** A hub's Z-Wave is single-threaded for OTA — never run two flashes into the same radio at once; chain them (`--wait-pid`) or run different hubs in parallel.
+
+## Source vendor-latest — NOT the hub's auto-discovery
+
+- `GET /hub/zwave/deviceFirmware/available?nodeId=N` (the Z-Wave JS firmware service) **lags and mis-matches**: it offered ZEN04 **2.30** when the vendor shipped **2.60** (missing the 2.40 redundant-report fix and the 2.50 SDK 7.19→7.24 S2/SPAN fix), and it offered a Springs shade a **bogus downgrade** to "1.5". Use it only as a rough "is there anything", never as the version/file.
+- Get the real latest from the vendor, and **read the change log** to justify the update: Zooz — free at `getzooz.com/firmware/<MODEL>_V<MM>R<mm>.zip` (`.gbl` 700/800, `.otz` 500); Leviton — free `.ota` on `leviton.com/content/dam/leviton/support/` (never cross model files); Ultraloq — free `.gbl` on `file.u-tec.com`. Some vendors publish **no** downloadable firmware (Springs/Somfy shades refuse "old motor" updates and aren't in the service) — then there is nothing to do; say so.
+- Newer is not always better: verify the change log addresses the problem, and heed community reports (Ultraloq 1.5 on 1.01 units often **fails outright** and can worsen lock-state reporting with no downgrade path; a Springs 13.3 motor is reported more reliable than 14.7).
+
+## The load-bearing hazard: a failed OR stalled OTA hangs the whole controller
+
+Grounded live twice (2026-07-22). A flash that **fails mid-transfer**, or **stalls** (percent freezes and never emits `DONE`/`FAILED`), hangs the entire zwaveJS controller — **not just that node**:
+
+- The hub keeps returning `success:true` to every command but **transmits nothing**; every Z-Wave node freezes at once.
+- **Zigbee is unaffected** — Zigbee sensors keep reporting. That asymmetry is the diagnostic tell: it's the Z-Wave *controller*, not the mesh, not the device.
+- The Hub-Mesh peer still shows `active/reachable` — invisible to the peer table (same class as `zwave-zigbee-mesh.md`'s "peer looks fine but drops commands"). Even a **local** command on the owning hub returns success but never reaches the node (its `lastTime` doesn't advance).
+- **Downstream blast radius:** frozen sensors go stale, which **staleness-poisons every lux/temperature-gated automation** — a "Motion at Dark" rule fired lights in daylight because the illuminance sensor's radio was hung at last night's value. A hung radio is not just frozen devices.
+
+**Why a big fleet hides it and a small one doesn't:** on a hub with many devices to flash, successes *after* a failure keep re-kicking the radio so a transient hang self-clears; on a hub with few devices, or when the **last/only** flash fails, nothing follows to shake it loose and the radio stays wedged silently. The trailing/only failure is the dangerous one.
+
+## Guardrails (all required — one alone is not enough)
+
+1. **No-progress watchdog.** Abort a flash if `percent` stops advancing for a few minutes at **ANY** level, not only at 0%. A frozen transfer never emits `DONE`/`FAILED`, so a plain start→wait-for-DONE loop hangs forever and takes the radio with it. (A canary-only guard *missed* a mid-transfer stall — that's why this is separate.)
+2. **Canary radio-health probe** between flashes: refresh a known-healthy **mains** node and confirm its Z-Wave `lastTime` advances. If it doesn't, the controller is hung → **reboot and re-check**; abort the batch if it stays hung.
+3. **RSSI floor.** Skip nodes at/below ~−95 dBm `lwrRssi` (SiLabs RX floor: −97 dBm 700-series, −110 dBm 800-LR) — floor-signal nodes are hang-prone and rarely flash. Not worth risking a whole-hub Z-Wave blackout to update one bathroom plug; force only when attended.
+
+Never fire-and-forget across marginal devices. Flash strong-signal devices; leave floor-RSSI ones on their current firmware.
+
+## Recovery and verification
+
+- **Reboot clears the hang**: `GET /hub/advanced/getManagementToken` → `GET /management/reboot?token=<token>` (~2–3 min; zwaveJS re-interviews every node; confirm a fresh `systemStart` in `/hub/eventsJson`). On the automation hub a reboot is a ~3-min blackout, so **prevention (the guardrails) beats recovery** here.
+- **Nothing bricks from a hang** — after recovery all nodes read `nodeState OK`; a stalled node sometimes even completes to target once the reboot frees the queue.
+- **Verify** each node against its target: the hub caches the old version in `device.data.firmwareVersion` until the post-reboot re-interview, so poll `/hub/zwave/deviceFirmware/details?nodeId=N` → `targets[0].version` until it flips. Report per device — updated / already-current / skipped-weak / failed — and name any failure with its current version (on old firmware, not bricked, retryable).

--- a/skills/_scripts/README.md
+++ b/skills/_scripts/README.md
@@ -20,6 +20,7 @@ end-of-life on 2024-10-07; CI runs 3.11.
 | `hub_mesh.py` | Fetch Z-Wave/Zigbee mesh detail **and hub-mesh peer health**; flag failed/ghost nodes, PER, weak routes, unreachable peers; rank staleness | HTTP |
 | `hub_radiolog.py` | Tail the `zwaveLogsocket`/`zigbeeLogsocket` for per-frame radio traffic | WebSocket |
 | `hub_device_usage.py` | Report where a device is used (blast radius) before removing it | HTTP |
+| `hub_fw_update.py` | Batch-flash Z-Wave firmware via the native zwaveJS updater, with a no-progress watchdog, canary radio-health probe + auto-reboot recovery, and an RSSI floor (a failed/stalled OTA can hang the whole controller) | HTTP |
 | `hubs_config.py` | Owner of `hubs.json` — init/add/set-default/remove/list hubs (imported + CLI) | — |
 
 The hub endpoints these drive are undocumented and version-sensitive — see `../_reference/endpoints.md`

--- a/skills/_scripts/hub_fw_update.py
+++ b/skills/_scripts/hub_fw_update.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""Batch-flash Z-Wave device firmware via Hubitat's native zwaveJS updater — safely.
+
+The hub's built-in "Device firmware updater" (Settings -> Z-Wave Details -> Maintenance)
+drives OTA over the same radio the devices already use — no driver swap, no self-hosting,
+and it handles LR + S2 that the community driver-swap updaters stall on. Its HTTP surface
+(verified live 2026-07-22 on 2.5.1.132, C-8 Pro, zwaveJS backend, Hub Security off — see
+../_reference/endpoints.md):
+
+    POST /hub/fileManager/upload/firmware              multipart .gbl/.otz/.ota (persists on hub, reusable per model)
+    GET  /hub/zwave/deviceFirmware/files               uploaded firmware files
+    GET  /hub/zwave/deviceFirmware/details?nodeId=N     {targets:[{target,version,firmwareIdHex}]}  (verify source)
+    POST /hub/zwave/deviceFirmware/start               {"nodeId":N,"target":0,"fileName":"X.gbl"}   begins OTA
+    GET  /hub/zwave/deviceFirmware/progress?nodeId=N    {progress:{percent,stage,status}}  stage PROCESS->SENDING->DONE
+
+Flow per node: verify current version (skip if already at target) -> start -> poll to DONE ->
+wait for NVM-commit+reboot -> poll /details until targets[0].version == target (the hub caches
+the old version until the post-reboot re-interview). Firmware for a model is reusable across every
+node of that model (upload once). Match the file to the device's HARDWARE REVISION (700 vs 800LR
+share a model name but need different images) — the wrong image bricks; the hub rejects a mismatch
+at /start, but do not rely on that.
+
+THE HAZARD THIS SCRIPT EXISTS FOR (grounded the hard way, 2026-07-22):
+A FAILED **or STALLED** OTA can hang the entire zwaveJS controller — not just skip that node.
+Symptom: the hub keeps returning success:true to commands but TRANSMITS NOTHING; every Z-Wave
+node freezes at once (Zigbee is unaffected — Zigbee sensors keep reporting, which is the tell that
+it is the Z-Wave *controller*, not the mesh or the device). The Hub-Mesh peer still shows
+active/reachable. Observed: a mid-transfer stall on a -99 dBm LR node hung the main hub's radio and,
+downstream, staleness-poisoned every lux/temperature-gated automation until a reboot.
+
+Two independent guards, both required (one is not enough — learned when a canary-only guard missed
+a mid-transfer stall):
+  1. NO-PROGRESS WATCHDOG. Abort a flash if `progress.percent` stops advancing for --stall-secs at
+     ANY percent (not only at 0%). A frozen transfer never emits FAILED/DONE, so a plain
+     start->wait-for-DONE loop hangs forever and takes the radio with it.
+  2. CANARY radio-health probe between flashes. Refresh a known-healthy MAINS node and confirm its
+     Z-Wave `lastTime` advances. If it does not, the controller is hung -> reboot and re-probe;
+     abort the batch if it does not come back.
+
+Plus an RSSI FLOOR: devices at/below --rssi-floor dBm (default -95; the Silicon Labs 700-series RX
+floor is -97, 800-series LR -110) are hang-prone and rarely flash — skip them unless --flash-weak.
+Not worth risking a whole-hub Z-Wave blackout to update one bathroom plug.
+
+Reboot recovery: GET /hub/advanced/getManagementToken -> GET /management/reboot?token=<token>
+(~2-3 min; zwaveJS re-interviews all nodes; verify a fresh systemStart in /hub/eventsJson).
+
+Worklist JSON (--worklist): [{"nodeId":N,"fileName":"X.gbl","target":"2.6","name":"..."}, ...]
+Progress goes to stderr; a JSON summary {ok,skipped,skipped_weak,failed,rebooted} to stdout.
+Idempotent (skips nodes already at target); MAX_CONSEC_FAIL circuit breaker; optional --wait-pid
+chains this run after another batch on the same radio finishes.
+"""
+import sys
+import os
+import json
+import time
+import argparse
+import urllib.request
+import urllib.error
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+# E402: import must follow the sys.path insert above so hubclient resolves when run as a script.
+from hubclient import HubError, resolve_base_from_args  # noqa: E402
+
+POLL_SECS = 15
+STALL_SECS = 240          # abort a flash if percent has not advanced for this long (at ANY %)
+XFER_TIMEOUT = 20 * 60    # hard ceiling per flash
+VERIFY_TIMEOUT = 4 * 60   # post-reboot re-interview ceiling
+CANARY_ADVANCE = 30       # seconds to wait for a canary lastTime to advance
+REBOOT_SETTLE = 120       # seconds for zwaveJS to re-init after a reboot comes back
+RSSI_FLOOR_DEFAULT = -95
+MAX_CONSEC_FAIL = 3
+
+
+def log(msg):
+    print(f"[{time.strftime('%H:%M:%S')}] {msg}", file=sys.stderr, flush=True)
+
+
+def _get(base, path):
+    with urllib.request.urlopen(base + path, timeout=20) as r:
+        return json.load(r)
+
+
+def _post(base, path, body):
+    req = urllib.request.Request(
+        base + path, data=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json"}, method="POST")
+    with urllib.request.urlopen(req, timeout=20) as r:
+        return json.load(r)
+
+
+def cur_version(base, node):
+    tg = _get(base, f"/hub/zwave/deviceFirmware/details?nodeId={node}").get("targets") or []
+    return tg[0].get("version") if tg else None
+
+
+def node_rssi(base, node):
+    """lwrRssi in dBm for a zwaveJS node (negative). None if unknown/legacy-scale."""
+    for n in _get(base, "/hub/zwaveDetails/json").get("nodes", []):
+        if n.get("nodeId") == node:
+            raw = (n.get("lwrRssi") or "").strip()
+            m = "".join(c for c in raw if c in "-0123456789")
+            try:
+                v = int(m)
+                return v if v < 0 else None   # only trust the zwaveJS absolute-dBm scale here
+            except ValueError:
+                return None
+    return None
+
+
+def node_lasttime(base, node):
+    for n in _get(base, "/hub/zwaveDetails/json").get("nodes", []):
+        if str(n.get("nodeId")) == str(node):
+            return n.get("lastTime")
+    return None
+
+
+def canary_transmits(base, canary_dev, canary_node):
+    """True if the controller actually transmits: refresh the canary, confirm lastTime advances."""
+    if not canary_dev:
+        return True
+    before = node_lasttime(base, canary_node)
+    try:
+        _post(base, "/device/runmethod", {"id": int(canary_dev), "method": "refresh"})
+    except Exception as e:
+        log(f"  canary refresh error: {e}")
+    for _ in range(CANARY_ADVANCE // 5):
+        time.sleep(5)
+        if node_lasttime(base, canary_node) != before:
+            return True
+    return False
+
+
+def reboot_hub(base):
+    log(f"!!! Z-Wave controller appears HUNG on {base} — rebooting to recover")
+    try:
+        tok = _get(base, "/hub/advanced/getManagementToken")
+        tok = tok if isinstance(tok, str) else tok.get("token", tok)
+        urllib.request.urlopen(f"{base}/management/reboot?token={tok}", timeout=15).read()
+    except Exception as e:
+        log(f"  reboot request error: {e}")
+    time.sleep(30)
+    for _ in range(40):  # wait for the web server to come back
+        try:
+            urllib.request.urlopen(f"{base}/hub/details/json", timeout=4).read()
+            break
+        except Exception:
+            time.sleep(5)
+    time.sleep(REBOOT_SETTLE)  # let zwaveJS finish interviewing
+    log("  hub back up; re-checking radio")
+
+
+def ensure_radio_ok(base, canary_dev, canary_node, allow_reboot):
+    """After each flash: if the radio is hung, reboot once and re-check. True if healthy."""
+    if not canary_dev:
+        return True
+    if canary_transmits(base, canary_dev, canary_node):
+        return True
+    if not allow_reboot:
+        log("  radio hung and --no-reboot set — aborting")
+        return False
+    reboot_hub(base)
+    if canary_transmits(base, canary_dev, canary_node):
+        log("  radio recovered after reboot")
+        return True
+    log("  radio STILL hung after reboot — aborting")
+    return False
+
+
+def flash(base, node, name, fname, target, rssi_floor, flash_weak):
+    v = cur_version(base, node)
+    if v == target:
+        log(f"SKIP node {node} ({name}) already {target}")
+        return "skipped"
+    rssi = node_rssi(base, node)
+    if not flash_weak and rssi is not None and rssi <= rssi_floor:
+        log(f"SKIP-WEAK node {node} ({name}) rssi {rssi}dBm <= floor {rssi_floor} — hang-prone; use --flash-weak to force")
+        return "skipped_weak"
+    log(f"START node {node} ({name}) {v} -> {target} [{fname}]" + (f" rssi {rssi}dBm" if rssi is not None else ""))
+    resp = _post(base, "/hub/zwave/deviceFirmware/start",
+                 {"nodeId": node, "target": 0, "fileName": fname})
+    if not resp.get("success", False):
+        log(f"ERROR node {node}: start rejected: {resp}")
+        return "failed"
+    t0 = time.time()
+    last_pct = None
+    last_change = time.time()
+    while True:
+        now = time.time()
+        if now - t0 > XFER_TIMEOUT:
+            log(f"ERROR node {node}: transfer exceeded {XFER_TIMEOUT}s ceiling")
+            return "failed"
+        # NO-PROGRESS WATCHDOG: a frozen transfer at ANY % hangs the radio and never emits DONE/FAILED.
+        if now - last_change > STALL_SECS:
+            log(f"ERROR node {node}: no progress for {STALL_SECS}s (stuck at {last_pct}%) — aborting (radio-hang risk)")
+            return "failed"
+        try:
+            p = _get(base, f"/hub/zwave/deviceFirmware/progress?nodeId={node}").get("progress", {})
+        except urllib.error.URLError as e:
+            log(f"  node {node}: progress read hiccup ({e})")
+            time.sleep(POLL_SECS)
+            continue
+        stage, pct = p.get("stage"), p.get("percent")
+        if pct != last_pct:
+            log(f"  node {node}: {pct}% {stage}")
+            last_pct = pct
+            last_change = now
+        if stage == "DONE":
+            break
+        if stage in ("ERROR", "FAILED", "ABORTED"):
+            log(f"ERROR node {node}: stage={stage} status={p.get('status')}")
+            return "failed"
+        time.sleep(POLL_SECS)
+    log(f"  node {node}: DONE, awaiting reboot/re-interview")
+    t1 = time.time()
+    while time.time() - t1 < VERIFY_TIMEOUT:
+        time.sleep(20)
+        try:
+            v = cur_version(base, node)
+        except urllib.error.URLError:
+            continue
+        if v == target:
+            log(f"OK node {node} ({name}) verified {target}")
+            return "ok"
+    log(f"ERROR node {node} ({name}): not verified, still {v}")
+    return "failed"
+
+
+def pid_alive(pid):
+    try:
+        os.kill(pid, 0)
+        return True
+    except (OSError, ProcessLookupError):
+        return False
+
+
+def run(base, work, canary_dev, canary_node, rssi_floor, flash_weak, allow_reboot, wait_pid):
+    if wait_pid:
+        log(f"waiting for pid {wait_pid} (prior batch on same radio) to finish…")
+        while pid_alive(wait_pid):
+            time.sleep(30)
+    log(f"=== fw batch: {len(work)} nodes on {base} "
+        f"(canary {canary_dev}:{canary_node}, rssi_floor {rssi_floor}) ===")
+    results = {"ok": [], "skipped": [], "skipped_weak": [], "failed": [], "rebooted": 0}
+    consec = 0
+    for w in work:
+        node, name = w["nodeId"], w.get("name", "?")
+        try:
+            r = flash(base, node, name, w["fileName"], w["target"], rssi_floor, flash_weak)
+        except Exception as e:
+            log(f"ERROR node {node} ({name}): unhandled {type(e).__name__}: {e}")
+            r = "failed"
+        results[r].append(f"{node} {name}")
+        consec = consec + 1 if r == "failed" else 0
+        if consec >= MAX_CONSEC_FAIL:
+            log(f"ABORT: {consec} consecutive failures — stopping to avoid cascading damage")
+            break
+        if not ensure_radio_ok(base, canary_dev, canary_node, allow_reboot):
+            log("ABORT: Z-Wave controller hung and did not recover")
+            break
+        time.sleep(5)
+    return results
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(description="Safely batch-flash Z-Wave firmware via the native zwaveJS updater.")
+    p.add_argument("--worklist", required=True,
+                   help='JSON: [{"nodeId":N,"fileName":"X.gbl","target":"2.6","name":"…"}, …]')
+    p.add_argument("--ip")
+    p.add_argument("--port", type=int, default=8080)
+    p.add_argument("--hub", help="named hub from hubs.json (when no --ip)")
+    p.add_argument("--hubs", help="path to hubs.json (default ./hubs.json when --hub is given)")
+    p.add_argument("--canary", help="devId:nodeId of a known-healthy MAINS node for the radio-health check")
+    p.add_argument("--rssi-floor", type=int, default=RSSI_FLOOR_DEFAULT,
+                   help=f"skip nodes with lwrRssi <= this dBm (default {RSSI_FLOOR_DEFAULT}); hang-prone")
+    p.add_argument("--flash-weak", action="store_true", help="flash even below the RSSI floor (attended only)")
+    p.add_argument("--no-reboot", action="store_true", help="do not auto-reboot on a hung radio (abort instead)")
+    p.add_argument("--wait-pid", type=int, help="block until this pid exits (chain after another batch)")
+    args = p.parse_args(argv)
+
+    try:
+        base = resolve_base_from_args(ip=args.ip, port=args.port, hub=args.hub, hubs_path=args.hubs)
+    except HubError as e:
+        print(str(e), file=sys.stderr)
+        return 2
+    try:
+        work = json.load(open(args.worklist))
+    except (OSError, ValueError) as e:
+        print(f"cannot read worklist: {e}", file=sys.stderr)
+        return 2
+    canary_dev, canary_node = (args.canary.split(":") if args.canary else (None, None))
+
+    results = run(base, work, canary_dev, canary_node, args.rssi_floor,
+                  args.flash_weak, not args.no_reboot, args.wait_pid)
+
+    log("=== SUMMARY ===")
+    for k in ("ok", "skipped", "skipped_weak", "failed"):
+        log(f"{k}: {len(results[k])}")
+        for x in results[k]:
+            log(f"   {x}")
+    print(json.dumps(results, indent=1))
+    return 1 if results["failed"] else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/firmware-update/SKILL.md
+++ b/skills/firmware-update/SKILL.md
@@ -7,6 +7,9 @@ description: Update Z-Wave device firmware on a Hubitat hub via the native zwave
 
 Process steps in order. Do not skip ahead.
 
+The always-on knowledge — why this is dangerous, the prerequisites, vendor-latest sourcing, and the
+guardrails — is `rules/firmware-update.md`. This skill is the step-by-step procedure; read the rule first.
+
 Hubitat's built-in **Device firmware updater** (Settings → Z-Wave Details → Maintenance) flashes OTA
 over the same radio the device already uses — no driver swap, no self-hosting, and it handles **LR +
 S2** that the community driver-swap updaters stall on. Its HTTP surface and every field are grounded

--- a/skills/firmware-update/SKILL.md
+++ b/skills/firmware-update/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: firmware-update
+description: Update Z-Wave device firmware on a Hubitat hub via the native zwaveJS updater — discover installed versions, find vendor-latest firmware, stage it, and batch-flash safely with a radio-hang watchdog. Use when the user wants to update/flash device firmware, check which devices are behind on firmware, or fix a device whose issue a firmware update addresses.
+---
+
+# Firmware-Update Skill
+
+Process steps in order. Do not skip ahead.
+
+Hubitat's built-in **Device firmware updater** (Settings → Z-Wave Details → Maintenance) flashes OTA
+over the same radio the device already uses — no driver swap, no self-hosting, and it handles **LR +
+S2** that the community driver-swap updaters stall on. Its HTTP surface and every field are grounded
+in `hub_fw_update.py` and `../_reference/endpoints.md`.
+
+**The load-bearing hazard:** a **failed OR stalled** OTA can hang the entire zwaveJS controller — the
+hub keeps returning `success:true` but transmits nothing, freezing every Z-Wave node at once (Zigbee
+is unaffected — that asymmetry is the tell). A mid-transfer stall on a weak node did exactly this to a
+main/automation hub and staleness-poisoned every lux/temperature-gated rule downstream until a reboot.
+Steps 5–6 exist to prevent and recover from that; never fire-and-forget a flash.
+
+## Step 1 — Frame the job
+
+Establish the hub (`--ip` or `--hub`) and confirm the backend is **zwaveJS** (`zwaveJS:true` in
+`/hub/zwaveDetails/json`) — this skill drives the zwaveJS updater. Identify the target device(s) and
+whether they are **mains or battery/FLiRS**: battery/sleepy devices (locks, most sensors) must be
+awake for the multi-minute transfer (USB power, fresh batteries, or operate them to wake). Proceed to Step 2.
+
+## Step 2 — Discover installed firmware
+
+Read installed versions over HTTP — no UI:
+- Bulk: `GET /device/fullJson/<deviceId>` → `device.data.{deviceModel, firmwareVersion, protocolVersion, manufacturer}`.
+- Per node (driver-independent): `GET /hub/zwave/deviceFirmware/details?nodeId=<n>` → `targets[0].version` + `firmwareIdHex`.
+
+Build a model + version + node/device-id map. Proceed to Step 3.
+
+## Step 3 — Find vendor-latest (NOT auto-discovery)
+
+`GET /hub/zwave/deviceFirmware/available?nodeId=<n>` exists but **must not be the source of truth** —
+it lags (offered ZEN04 2.30 when 2.60 shipped, missing the SDK/S2 fixes) and mis-matches (offered a
+Springs shade a bogus downgrade). Get the real latest from the vendor:
+- **Zooz** — the OTA files page lists every model/version; direct free download `getzooz.com/firmware/<MODEL>_V<MM>R<mm>.zip` (`.gbl` 700/800, `.otz` 500). Read the per-model **change log** to justify the update.
+- **Leviton** — free `.ota` on `leviton.com/content/dam/leviton/support/`. Never cross model files.
+- Others vary; some (e.g. Springs shades) publish **no** downloadable firmware — say so and stop.
+
+**Hardware revision decides the image.** 700-series and 800LR share a model name but need different
+files; pick by the installed major version. The wrong image can brick — the hub rejects a mismatch at
+`/start`, but do not rely on that. Unzip to the raw `.gbl`/`.otz`. Proceed to Step 4.
+
+## Step 4 — Stage the firmware on the hub
+
+Upload once per model — it persists and is reusable across every node of that model:
+
+```
+curl -F "uploadFile=@<MODEL>_V<MM>R<mm>.gbl" http://<hub>:8080/hub/fileManager/upload/firmware
+```
+
+Confirm via `GET /hub/zwave/deviceFirmware/files`. Proceed to Step 5.
+
+## Step 5 — Flash with the safeguards
+
+Write a worklist `[{"nodeId":N,"fileName":"X.gbl","target":"2.6","name":"…"}, …]` and run:
+
+```
+python3 skills/_scripts/hub_fw_update.py --ip <addr> --worklist work.json --canary <devId>:<nodeId>
+```
+
+Full argument/flow/hazard contract: the `hub_fw_update.py` module docstring. It is idempotent (skips
+nodes already at target) and carries **two required guards plus a floor**:
+- **No-progress watchdog** — aborts a flash if `percent` stops advancing at **any** level (a frozen
+  transfer never emits DONE/FAILED and would hang the radio forever).
+- **Canary** (`--canary devId:nodeId`, a known-healthy **mains** node) — after each flash, confirms the
+  controller still transmits; if not, it **reboots the hub and re-checks**, aborting if it stays hung.
+- **RSSI floor** (`--rssi-floor`, default −95 dBm) — skips hang-prone floor-signal nodes; override only
+  when attended with `--flash-weak`.
+
+**One batch per radio** (a hub's Z-Wave is single-threaded for OTA); use `--wait-pid` to chain a second
+batch after the first, or run different hubs in parallel. Never run two flashes into the same radio at
+once. Proceed to Step 6.
+
+## Step 6 — Verify and account
+
+The script verifies each node against its target (the hub caches the old version until the post-reboot
+re-interview, so `/details` is polled until it flips). Re-read `device.data.firmwareVersion` for a
+second confirmation. Report per device: updated / skipped (already current) / skipped-weak / failed —
+and for any failure, that the device is **on old firmware, not bricked** (`nodeState OK`) and retryable.
+Do not silently drop the weak/failed nodes; name them and their current version.


### PR DESCRIPTION
Adds the `firmware-update` skill proposed in #64, grounded live this session (2.5.1.132, zwaveJS, C-8 Pro).

## What
- **`skills/_scripts/hub_fw_update.py`** — batch-flashes a Z-Wave firmware worklist via the hub's **native zwaveJS updater** (`/hub/zwave/deviceFirmware/*`): no driver swap, handles LR+S2, flashes in place.
- **`skills/firmware-update/SKILL.md`** — discover installed versions → find **vendor-latest** (not auto-discovery, which lags/mis-matches) → stage → flash → verify.

## The guards (learned the hard way — see #64)
A **failed _or stalled_** OTA hangs the whole zwaveJS controller: the hub returns `success:true` but transmits nothing, freezing every Z-Wave node at once (Zigbee unaffected — the tell). It took down a main/automation hub and staleness-poisoned lux/temp-gated rules until a reboot.

Two guards, both required (a canary-only guard missed a mid-transfer stall):
1. **No-progress watchdog** — aborts if `percent` stops advancing at **any** level, not just 0%.
2. **Canary** radio-health probe between flashes — refresh a known-healthy mains node, confirm its `lastTime` advances; if not, **reboot + re-check**, abort if still hung.

Plus an **RSSI floor** (default −95 dBm) that skips hang-prone floor-signal nodes (`--flash-weak` to override, attended only), idempotent skip, a consecutive-failure circuit breaker, and `--wait-pid` to chain batches on one radio.

Smoke-tested end-to-end against a live hub (resolve → version read → idempotent skip → canary → JSON summary). Follows `_scripts` conventions (stdlib-only, `hubclient` resolution, grounding docstring, JSON to stdout / progress to stderr, entry guard). Closes #64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)