### PR TITLE
fix(hub_fw_update): read management token as text, not JSON (auto-reboot recovery was a no-op)

### DIFF
--- a/.tessl-plugin/plugin.json
+++ b/.tessl-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jbaruch/hubitat-dev",
-  "version": "0.1.38",
+  "version": "0.1.39",
   "description": "Context for developing and debugging Hubitat Elevation apps, drivers, and hub environment — sandbox constraints, lifecycle idioms, capability contracts, plus grounded deploy/log-tail/lint mechanisms.",
   "private": false,
   "rules": "rules/",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.1.39 — 2026-07-22
+
+### Fixed
+
+- **`hub_fw_update.py` auto-reboot recovery could not get a management token** (`skills/_scripts/hub_fw_update.py`). `GET /hub/advanced/getManagementToken` returns a **bare token string**, not JSON — the reboot path read it with `json.load`, which threw `Expecting value: line 1 column 1`, so when a failed OTA hung the controller the guard detected the hang but **never actually rebooted**. Caught live: a ZEN76 flash hit `stage=FAILED`, the canary correctly saw the radio hung, then the reboot silently no-op'd and the hub stayed hung until a manual reboot. Fixed to read the token as text (`.read().decode().strip().strip('"')`). The detection half (watchdog + canary) worked; only the recovery half was broken.
+
+
 ## 0.1.38 — 2026-07-22
 
 ### Added

--- a/skills/_scripts/hub_fw_update.py
+++ b/skills/_scripts/hub_fw_update.py
@@ -133,8 +133,9 @@ def canary_transmits(base, canary_dev, canary_node):
 def reboot_hub(base):
     log(f"!!! Z-Wave controller appears HUNG on {base} — rebooting to recover")
     try:
-        tok = _get(base, "/hub/advanced/getManagementToken")
-        tok = tok if isinstance(tok, str) else tok.get("token", tok)
+        # NB: /hub/advanced/getManagementToken returns a BARE token string, not JSON — read as text.
+        with urllib.request.urlopen(base + "/hub/advanced/getManagementToken", timeout=15) as r:
+            tok = r.read().decode("utf-8", "replace").strip().strip('"')
         urllib.request.urlopen(f"{base}/management/reboot?token={tok}", timeout=15).read()
     except Exception as e:
         log(f"  reboot request error: {e}")


### PR DESCRIPTION
Bugfix to the firmware-update guard from #65.

`GET /hub/advanced/getManagementToken` returns a **bare token string**, not JSON. `reboot_hub()` parsed it with `json.load` → `Expecting value: line 1 column 1`, so when a failed OTA hung the controller the guard **detected** the hang but **never rebooted** — the recovery half silently no-op'd.

Caught live retrying stragglers: a ZEN76 flash hit `stage=FAILED`, the canary correctly saw the radio hung, the reboot threw and no-op'd, and the hub stayed hung until a manual reboot. The detection half (no-progress watchdog + canary) worked; only recovery was broken.

Fix: read the token as text (`.read().decode().strip().strip('"')`) — verified live (len 64) against the hub. v0.1.39.

🤖 Generated with [Claude Code](https://claude.com/claude-code)