### PR TITLE
fix(hub_fw_update): raise transfer ceiling 20->35 min (slow marginal-link devices)

### DIFF
--- a/.tessl-plugin/plugin.json
+++ b/.tessl-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jbaruch/hubitat-dev",
-  "version": "0.1.41",
+  "version": "0.1.42",
   "description": "Context for developing and debugging Hubitat Elevation apps, drivers, and hub environment — sandbox constraints, lifecycle idioms, capability contracts, plus grounded deploy/log-tail/lint mechanisms.",
   "private": false,
   "rules": "rules/",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.42 — 2026-07-22
+
+### Fixed
+
+- **`hub_fw_update.py` gave up on a slow device one step short of the finish** (`skills/_scripts/hub_fw_update.py`). The per-flash `XFER_TIMEOUT` hard ceiling was 20 min, but a marginal-link Leviton/ZEN04 (~−90 dBm) transfers slowly — one hit the ceiling at **93%** and was logged `failed`, yet the device **completed the OTA on its own** moments later and re-interviewed at the target version (confirmed: the very next idempotent run `SKIP`ped it as already-current). The ceiling is only a backstop; the **no-progress watchdog** (abort if `percent` stalls at any level) is the real hang guard, so a slow-but-still-advancing transfer must not be killed at an artificial limit. Raised to 35 min. Fourth and final live-hardened tuning (0.1.39 reboot token, 0.1.40 only-after-failure, 0.1.41 any-node/wide-window canary, 0.1.42 generous ceiling).
+
 ## 0.1.41 — 2026-07-22
 
 ### Fixed

--- a/skills/_scripts/hub_fw_update.py
+++ b/skills/_scripts/hub_fw_update.py
@@ -64,7 +64,10 @@ from hubclient import HubError, resolve_base_from_args  # noqa: E402
 
 POLL_SECS = 15
 STALL_SECS = 240          # abort a flash if percent has not advanced for this long (at ANY %)
-XFER_TIMEOUT = 20 * 60    # hard ceiling per flash
+XFER_TIMEOUT = 35 * 60    # hard backstop per flash; the no-progress watchdog is the real hang guard,
+#                           so this stays generous — a slow-but-still-advancing transfer (marginal
+#                           link) must not be killed at an artificial ceiling (a ZEN04/Leviton at
+#                           ~-90 dBm hit 93% at the old 20 min ceiling and was failed one step short)
 VERIFY_TIMEOUT = 4 * 60   # post-reboot re-interview ceiling
 CANARY_WINDOW = 75        # seconds to watch for ANY node's lastTime to advance (radio-alive)
 REBOOT_SETTLE = 150       # seconds for zwaveJS to re-init (interview all nodes) after a reboot


### PR DESCRIPTION
Fourth and final live-hardened tuning of the firmware harness (after #66/#67/#68).

**Bug:** the per-flash `XFER_TIMEOUT` hard ceiling was 20 min. A marginal-link Leviton/ZEN04 (~−90 dBm) transfers slowly — one hit the ceiling at **93%** and was logged `failed`, yet the device **completed the OTA on its own** moments later and re-interviewed at the target version (the very next idempotent run `SKIP`ped it as already-current). So it was a false failure.

**Fix:** the ceiling is only a backstop — the **no-progress watchdog** (abort if `percent` stalls at any level) is the real hang guard, so a slow-but-still-advancing transfer must not be killed at an artificial limit. Raised to 35 min.

Together, #66–#68 and this PR hardened the harness through four distinct live failures (reboot token, canary-after-success, single-node/tight-window canary, tight ceiling) — every fix came from a real hub, not speculation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)