### PR TITLE
docs(rules): add self-reported-vs-measured rule (#78)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Added
+
+- **New rule `self-reported-vs-measured.md`** (`rules/self-reported-vs-measured.md`, `README.md`, part of #78). The hardest lesson of the irrigation recon, and a platform-reading rule rather than a domain one: a cloud integration's child-device attributes arrive through one `sendEvent` path and render identically in Current States, but some are sensor readings and some are model output computed from hand-entered config that was never validated. The built-in Rachio integration's `depthOfWater` reads exactly like a soil-moisture sensor and is the output of an evapotranspiration model whose inputs (crop type, nozzle, slope, area) were each typed once. The rule: ask **measured or computed** before trusting an attribute; **detect it by timestamp** (config echoes freeze at the install timestamp, live state carries a recent one — check whether `currentStates[attr].date` moved since install); **rank suspicion by observability, not by who typed it** (look-and-see fields like nozzle type stay reliable hand-entered, instrument-required fields like slope/area do not, and their errors are directional); **never impeach one guess with another**; **map the model empirically** with the constructive technique — change one field in the vendor app, `POST /device/runmethod {"method":"refresh"}`, diff `fullJson.currentStates` (establish which inputs matter before correcting any — `zoneSquareFeet` drove a usage report, not water volume); and mind **publishing gaps** — an integration publishes the subset its author chose, and the two most consequential fields may be absent. Rule is auto-included via the `rules/` directory in `.tessl-plugin/plugin.json`; no manifest edit needed.
+
 ## 0.1.47 — 2026-07-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ All rules are always-on — installing the plugin means you want this context.
 | [driver-lifecycle](rules/driver-lifecycle.md) | Driver callbacks, the capability contract (declare = must implement), and the `parse()` dispatch pattern. |
 | [logging-conventions](rules/logging-conventions.md) | The `logEnable`/`txtEnable` toggles and the `runIn(1800, logsOff)` auto-disable idiom. |
 | [state-vs-attributes](rules/state-vs-attributes.md) | Attributes via `sendEvent` (subscribable) vs. `state`/`atomicState` (private, JSON-serializable). Why a value's timestamp can't tell you the source is alive. |
+| [self-reported-vs-measured](rules/self-reported-vs-measured.md) | A cloud integration's attributes aren't all measurements — some are model output from hand-entered config. Tell measured from computed by timestamp, rank suspicion by observability, and map the model with `runmethod` refresh + diff. |
 | [groovy-gotchas](rules/groovy-gotchas.md) | Silent-failure traps the compiler misses: string handler names, `0`-is-falsy, null device inputs, reserved names. |
 | [multi-hub-topology](rules/multi-hub-topology.md) | Code is per-hub-by-IP, devices can mesh; local-no-security assumption; the deploy version token. |
 | [zwave-zigbee-mesh](rules/zwave-zigbee-mesh.md) | What the Z-Wave/Zigbee mesh metrics mean, including `listening` vs `beaming`, hex routes, the two-scale `lwrRssi` split, and `lastActivity` vs misleading `active`. |

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ All rules are always-on — installing the plugin means you want this context.
 | [driver-lifecycle](rules/driver-lifecycle.md) | Driver callbacks, the capability contract (declare = must implement), and the `parse()` dispatch pattern. |
 | [logging-conventions](rules/logging-conventions.md) | The `logEnable`/`txtEnable` toggles and the `runIn(1800, logsOff)` auto-disable idiom. |
 | [state-vs-attributes](rules/state-vs-attributes.md) | Attributes via `sendEvent` (subscribable) vs. `state`/`atomicState` (private, JSON-serializable). Why a value's timestamp can't tell you the source is alive. |
-| [self-reported-vs-measured](rules/self-reported-vs-measured.md) | A cloud integration's attributes aren't all measurements — some are model output from hand-entered config. Tell measured from computed by timestamp, rank suspicion by observability, and map the model with `runmethod` refresh + diff. |
+| [self-reported-vs-measured](rules/self-reported-vs-measured.md) | Distinguishing a cloud integration's measured attributes from model output computed off hand-entered config. Tell them apart by timestamp, rank suspicion by observability, and map the model with `runmethod` refresh + diff. |
 | [groovy-gotchas](rules/groovy-gotchas.md) | Silent-failure traps the compiler misses: string handler names, `0`-is-falsy, null device inputs, reserved names. |
 | [multi-hub-topology](rules/multi-hub-topology.md) | Code is per-hub-by-IP, devices can mesh; local-no-security assumption; the deploy version token. |
 | [zwave-zigbee-mesh](rules/zwave-zigbee-mesh.md) | What the Z-Wave/Zigbee mesh metrics mean, including `listening` vs `beaming`, hex routes, the two-scale `lwrRssi` split, and `lastActivity` vs misleading `active`. |

--- a/rules/self-reported-vs-measured.md
+++ b/rules/self-reported-vs-measured.md
@@ -1,0 +1,43 @@
+---
+alwaysApply: true
+description: A cloud integration's attributes are not all measurements — some are model output computed from hand-entered config; tell measured from computed before trusting or correcting them
+---
+
+# Self-Reported vs. Measured
+
+A cloud integration's child-device attributes arrive through one `sendEvent` path and render identically in the Current States table, yet some are sensor readings and some are model output computed from configuration a human typed once and never validated. Reading a computed value as evidence launders a guess into a fact.
+
+## Measured or computed
+
+- Before trusting any attribute from a cloud integration, ask whether the upstream service **measures** it or **computes** it. Both look identical from Hubitat.
+- A computed attribute is model output; its inputs are hand-entered config (crop type, nozzle, slope, area), each entered once with no validation.
+- Plausibility is not evidence. Ten zones reporting an identical value despite differing inputs is evidence — that the model echoes config rather than tracks the ground.
+- When an app writes a derived attribute a rule might subscribe to, name it so a future reader can tell it is derived.
+
+## Detect it by timestamp
+
+- Config echoed back freezes at the **install timestamp**; live state carries a **recent** timestamp. Both arrive via `sendEvent` and render identically.
+- Before trusting a cloud attribute, check whether its `currentStates[<attr>].date` has moved since install (`skills/_reference/endpoints.md`). A round value, identical across units, unchanged since install is a default, not a measurement.
+
+## Rank suspicion by observability
+
+- The error rate tracks how hard the underlying fact is to **observe**, not whether a human typed it.
+- Look-and-see fields (nozzle type, soil type) stay reliable even when hand-entered. Instrument-required fields (slope, area) do not, and their errors are **directional** — an understated grade reads as level when you stand on it.
+- The person who entered the data is itself a source — ask which fields they measured, which they eyeballed, and which they left at the default. That ranks the whole set in one question.
+
+## Never impeach one guess with another
+
+- Using one unverified field to argue a second is wrong produces a confident conclusion from two guesses.
+- Verify a suspect config field against an independent measurement, never against a neighboring self-reported field.
+
+## Map the model empirically
+
+- The integration publishes both the inputs and the outputs — the input→output wiring is measurable from the hub without vendor docs.
+- Change exactly one field in the vendor's own app, then `POST /device/runmethod {"method":"refresh"}` and diff `fullJson.currentStates` before and after (`skills/_reference/endpoints.md`). `refresh` collapses the integration's poll wait to seconds and makes the loop deterministic.
+- Establish which inputs matter **before** correcting any — field names do not state the wiring (`zoneSquareFeet` drove a usage report, not water volume).
+- Two units with matching inputs producing matching outputs confirms the model is deterministic and the full input set is identified; a mismatch means a hidden input.
+
+## Publishing gaps
+
+- A cloud integration publishes the subset its author chose, not the subset that matters.
+- Enumerate what it actually publishes against the vendor's own app before designing around it — the two most consequential fields may be the absent ones.

--- a/rules/self-reported-vs-measured.md
+++ b/rules/self-reported-vs-measured.md
@@ -36,7 +36,7 @@ A cloud integration's child-device attributes arrive through one `sendEvent` pat
 - Change exactly one field in the vendor's own app.
 - `POST /device/runmethod {"method":"refresh"}` to force the integration's read immediately (`skills/_reference/endpoints.md`).
 - Diff `fullJson.currentStates` before and after to see which outputs that field drove.
-- Establish which inputs matter **before** correcting any. Field names do not state the wiring; `zoneSquareFeet` drove a usage report, not water volume.
+- Establish which inputs matter **before** correcting any. Field names do not state the wiring.
 - Two units with matching inputs producing matching outputs confirms the model is deterministic and the full input set is identified; a mismatch means a hidden input.
 
 ## Publishing gaps

--- a/rules/self-reported-vs-measured.md
+++ b/rules/self-reported-vs-measured.md
@@ -1,6 +1,6 @@
 ---
 alwaysApply: true
-description: A cloud integration's attributes are not all measurements — some are model output computed from hand-entered config; tell measured from computed before trusting or correcting them
+description: Telling a cloud integration's measured attributes from its computed ones (model output from hand-entered config) before trusting or correcting them
 ---
 
 # Self-Reported vs. Measured
@@ -10,19 +10,20 @@ A cloud integration's child-device attributes arrive through one `sendEvent` pat
 ## Measured or computed
 
 - Before trusting any attribute from a cloud integration, ask whether the upstream service **measures** it or **computes** it. Both look identical from Hubitat.
-- A computed attribute is model output; its inputs are hand-entered config (crop type, nozzle, slope, area), each entered once with no validation.
+- A computed attribute is model output. Its inputs are hand-entered config (crop type, nozzle, slope, area), each entered once with no validation.
 - Plausibility is not evidence. An identical value across many units with differing inputs is evidence the model echoes config, not the ground.
 - When an app writes a derived attribute a rule might subscribe to, name it so a future reader can tell it is derived.
 
 ## Detect it by timestamp
 
-- Config echoed back freezes at the **install timestamp**; live state carries a **recent** timestamp. Both arrive via `sendEvent` and render identically.
+- Config echoed back freezes at the **install timestamp**. Live state carries a **recent** timestamp. Both arrive via `sendEvent` and render identically.
 - Before trusting a cloud attribute, check whether its `currentStates[<attr>].date` has moved since install (`skills/_reference/endpoints.md`). A round value, identical across units, unchanged since install is a default, not a measurement.
 
 ## Rank suspicion by observability
 
 - The error rate tracks how hard the underlying fact is to **observe**, not whether a human typed it.
-- Look-and-see fields (nozzle type, soil type) stay reliable even when hand-entered. Instrument-required fields (slope, area) do not, and their errors are **directional**, not random.
+- Look-and-see fields (nozzle type, soil type) stay reliable even when hand-entered.
+- Instrument-required fields (slope, area) do not, and their errors are **directional**, not random.
 - The person who entered the data is itself a source. Ask which fields they measured, which they eyeballed, and which they left at the default. That ranks the whole set in one question.
 
 ## Never impeach one guess with another
@@ -37,7 +38,8 @@ A cloud integration's child-device attributes arrive through one `sendEvent` pat
 - `POST /device/runmethod {"method":"refresh"}` to force the integration's read immediately (`skills/_reference/endpoints.md`).
 - Diff `fullJson.currentStates` before and after to see which outputs that field drove.
 - Establish which inputs matter **before** correcting any. Field names do not state the wiring.
-- Two units with matching inputs producing matching outputs confirms the model is deterministic and the full input set is identified; a mismatch means a hidden input.
+- Two units with matching inputs producing matching outputs confirms the model is deterministic and the full input set is identified.
+- A mismatch means a hidden input.
 
 ## Publishing gaps
 

--- a/rules/self-reported-vs-measured.md
+++ b/rules/self-reported-vs-measured.md
@@ -11,7 +11,7 @@ A cloud integration's child-device attributes arrive through one `sendEvent` pat
 
 - Before trusting any attribute from a cloud integration, ask whether the upstream service **measures** it or **computes** it. Both look identical from Hubitat.
 - A computed attribute is model output; its inputs are hand-entered config (crop type, nozzle, slope, area), each entered once with no validation.
-- Plausibility is not evidence. Ten zones reporting an identical value despite differing inputs is evidence — that the model echoes config rather than tracks the ground.
+- Plausibility is not evidence. An identical value across many units with differing inputs is evidence the model echoes config, not the ground.
 - When an app writes a derived attribute a rule might subscribe to, name it so a future reader can tell it is derived.
 
 ## Detect it by timestamp
@@ -22,8 +22,8 @@ A cloud integration's child-device attributes arrive through one `sendEvent` pat
 ## Rank suspicion by observability
 
 - The error rate tracks how hard the underlying fact is to **observe**, not whether a human typed it.
-- Look-and-see fields (nozzle type, soil type) stay reliable even when hand-entered. Instrument-required fields (slope, area) do not, and their errors are **directional** — an understated grade reads as level when you stand on it.
-- The person who entered the data is itself a source — ask which fields they measured, which they eyeballed, and which they left at the default. That ranks the whole set in one question.
+- Look-and-see fields (nozzle type, soil type) stay reliable even when hand-entered. Instrument-required fields (slope, area) do not, and their errors are **directional**, not random.
+- The person who entered the data is itself a source. Ask which fields they measured, which they eyeballed, and which they left at the default. That ranks the whole set in one question.
 
 ## Never impeach one guess with another
 
@@ -32,12 +32,15 @@ A cloud integration's child-device attributes arrive through one `sendEvent` pat
 
 ## Map the model empirically
 
-- The integration publishes both the inputs and the outputs — the input→output wiring is measurable from the hub without vendor docs.
-- Change exactly one field in the vendor's own app, then `POST /device/runmethod {"method":"refresh"}` and diff `fullJson.currentStates` before and after (`skills/_reference/endpoints.md`). `refresh` collapses the integration's poll wait to seconds and makes the loop deterministic.
-- Establish which inputs matter **before** correcting any — field names do not state the wiring (`zoneSquareFeet` drove a usage report, not water volume).
+- The integration publishes both the inputs and the outputs. The input→output wiring is measurable from the hub without vendor docs.
+- Change exactly one field in the vendor's own app.
+- `POST /device/runmethod {"method":"refresh"}` to force the integration's read immediately (`skills/_reference/endpoints.md`).
+- Diff `fullJson.currentStates` before and after to see which outputs that field drove.
+- Establish which inputs matter **before** correcting any. Field names do not state the wiring; `zoneSquareFeet` drove a usage report, not water volume.
 - Two units with matching inputs producing matching outputs confirms the model is deterministic and the full input set is identified; a mismatch means a hidden input.
 
 ## Publishing gaps
 
 - A cloud integration publishes the subset its author chose, not the subset that matters.
-- Enumerate what it actually publishes against the vendor's own app before designing around it — the two most consequential fields may be the absent ones.
+- Enumerate what it actually publishes against the vendor's own app before designing around it.
+- The absent fields may be the consequential ones.


### PR DESCRIPTION
**PR 2 of ~6 for #78** — the conceptual heart of the irrigation recon, and a platform-reading rule rather than a domain one.

A cloud integration's child-device attributes arrive through one `sendEvent` path and render identically in Current States, but some are sensor readings and some are **model output computed from hand-entered config that was never validated**. The built-in Rachio integration's `depthOfWater` reads exactly like a soil-moisture sensor; it's the output of an evapotranspiration model whose inputs (crop type, nozzle, slope, area) were each typed once. Reading it as evidence launders a guess into a fact.

## The rule (`rules/self-reported-vs-measured.md`, always-on)
- **Measured or computed** — ask before trusting; both look identical from Hubitat. Plausibility isn't evidence; identical values across differing inputs *is* evidence (the model echoes config).
- **Detect it by timestamp** — config echoes freeze at the install timestamp, live state carries a recent one; check whether `currentStates[attr].date` moved since install.
- **Rank suspicion by observability, not by who typed it** — look-and-see fields (nozzle) stay reliable hand-entered; instrument-required fields (slope, area) don't, and their errors are directional.
- **Never impeach one guess with another** — verify a suspect field against an independent measurement, not a neighboring self-reported one.
- **Map the model empirically** — change one field in the vendor app → `POST /device/runmethod {"method":"refresh"}` → diff `fullJson.currentStates`. Establish which inputs matter before correcting any (`zoneSquareFeet` drove a usage report, not water volume).
- **Publishing gaps** — an integration publishes its author's subset; the two most consequential fields may be absent.

## Surface sync
- Rule auto-included via the `rules/` directory glob in `.tessl-plugin/plugin.json` (no manifest edit).
- README rules table + CHANGELOG updated.

## Verification
- `tessl plugin lint` ✔ valid; self-audited against `context-writing-style` (no why-connectives; coherent multi-aspect policy area).

🤖 Generated with [Claude Code](https://claude.com/claude-code)