### PR TITLE
feat(device-command): new skill to run a device command and verify it landed (#78)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Added
+
+- **New skill `device-command` — run a device command over HTTP and confirm it landed** (`skills/device-command/SKILL.md`, `skills/_scripts/hub_device_command.py` + tests, `skills/_scripts/hubclient.py`, `README.md`, part of #78). Closes the "make the thing do the thing, then observe it" gap the irrigation recon surfaced: there was a grounded path to read a device's command surface but none to *run* a command and verify it. The script enumerates the authoritative command surface from `fullJson.commands[]` (rejecting an unknown name with the valid list, including driver custom commands), coerces each argument to its declared `parameters[].type`, POSTs `/device/runmethod` as JSON, then re-reads the command's `relatedAttribute` from `currentStates` to report whether it moved. The load-bearing contract: `{"success":true}` means the method was **dispatched, not executed** — a throwing method or a command to the already-current state returns the identical payload, and the change filter hides the no-op, so an unchanged attribute is reported as `unchanged`, never as failure (confirm intent via `eventsJson`). `--list` prints the command surface and runs nothing; `--name` resolves a device by exact display name. `hubclient._urllib_transport` gained an optional `content_type` (JSON for `runmethod`), backward-compatible with the form-encoded code endpoints. Deterministic core (surface validation, arg coercion, state diff, response parsing) is unit-tested without a hub (32 tests). Skill auto-included via the `skills/` directory glob.
+
 ## 0.1.49 — 2026-07-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ All rules are always-on — installing the plugin means you want this context.
 | [lint-review](skills/lint-review/SKILL.md) | Linting Groovy for sandbox violations and silent-failure traps, then judging each finding. |
 | [test](skills/test/SKILL.md) | Setting up offline unit tests (biocomp/hubitat_ci) so logic is exercised off-hub. |
 | [hub-config](skills/hub-config/SKILL.md) | Managing `hubs.json` — register, list, and set the default hub (action router). |
+| [device-command](skills/device-command/SKILL.md) | Running a command on a device over HTTP and confirming it landed — enumerate the real command surface, send it, and verify by re-reading the related attribute (dispatched ≠ executed). |
 | [device-removal](skills/device-removal/SKILL.md) | Safely removing a device — enumerate usage, warn on blast radius, verify after, and restore references onto a replacement. |
 | [device-migration](skills/device-migration/SKILL.md) | Moving every app reference from an old device to a new one — Swap Device, a virtual bridge/parking slot, a Hub Mesh re-home across hubs, or a guided manual re-select, chosen by why the swap is blocked. |
 

--- a/skills/_scripts/README.md
+++ b/skills/_scripts/README.md
@@ -20,6 +20,7 @@ end-of-life on 2024-10-07; CI runs 3.11.
 | `hub_mesh.py` | Fetch Z-Wave/Zigbee mesh detail **and hub-mesh peer health**; flag failed/ghost nodes, PER, weak routes, incomplete joins, unreachable peers; rank timestamp liveness | HTTP |
 | `hub_radiolog.py` | Tail the `zwaveLogsocket`/`zigbeeLogsocket` for per-frame radio traffic | WebSocket |
 | `hub_device_usage.py` | Report a device's delete blast radius; `--live` audits subscriptions and Rule Machine `trigDevs` separately | HTTP |
+| `hub_device_command.py` | Run a command on a device (enumerate the real command surface, coerce args, POST `runmethod`) and verify it landed by re-reading the `relatedAttribute` | HTTP |
 | `hub_fw_update.py` | Batch-flash Z-Wave firmware via the native zwaveJS updater, with a no-progress watchdog, canary radio-health probe + auto-reboot recovery, and an RSSI floor (a failed/stalled OTA can hang the whole controller) | HTTP |
 | `hubs_config.py` | Owner of `hubs.json` — init/add/set-default/remove/list hubs (imported + CLI) | — |
 

--- a/skills/_scripts/hub_device_command.py
+++ b/skills/_scripts/hub_device_command.py
@@ -1,0 +1,361 @@
+#!/usr/bin/env python3
+"""Run a command on a Hubitat device and confirm it landed — enumerate the real command
+surface, execute over the undocumented runmethod endpoint, and verify by observation.
+
+Grounded live on 2.5.1.134–135 (C-8 Pro, Hub Security off — see ../_reference/endpoints.md):
+
+    GET  /device/fullJson/<id>   -> {device:{currentStates[...]}, commands:[...], ...}
+    POST /device/runmethod       {"id":<id>,"method":"<cmd>","args":[...]}  -> {"success":<bool>,"message":<str|null>}
+
+The command surface is `commands[]` from fullJson — each `{name, parameters:[{type, defaultValue}],
+arguments, relatedAttribute, capability:<bool>}`. It is authoritative and includes driver custom
+commands (`capability:false`) that inferring from the declared capability would miss. This script
+validates the requested command against that list (rejecting an unknown name with the valid set) and
+coerces each argument to its declared `parameters[].type` before sending — `setZoneWaterTime` takes a
+number, and a string would fail oddly.
+
+**A runmethod return code is not evidence the command executed.** The hub answers `{"success":true}`
+when the Groovy method is *dispatched*, not when the device moved — a method that throws, or a command
+to the state the device is already in, returns the identical payload. In the already-in-state case the
+platform's change filter suppresses the event too (rules/state-vs-attributes.md), so "no event" does
+not distinguish worked from failed. Verification here re-reads the command's `relatedAttribute` from
+`currentStates` and reports whether its value changed — an unchanged attribute is reported as
+`unchanged`, never as failure, because change-to-current-state is a legitimate no-op.
+
+The deterministic pieces (command lookup, argument coercion, state diff, response parsing) are pure
+functions unit-tested without a hub; only the fetch/run functions touch the network via an injectable
+`transport`.
+
+Usage:
+    hub_device_command.py --ip 192.0.2.11 --device 1639 --command refresh
+    hub_device_command.py --ip 192.0.2.11 --device 1639 --command setLevel --arg 40 --arg 5
+    hub_device_command.py --ip 192.0.2.11 --name "Zone 8 Soil" --command on
+    hub_device_command.py --ip 192.0.2.11 --device 1639 --list          # print the command surface, run nothing
+    hub_device_command.py --hub main --device 1639 --command on          # resolve via ./hubs.json
+Exactly one of --device / --name is required. --command is required unless --list. Output: one JSON
+object on stdout ({hub, device_id, command, args, dispatched, response, verification}). Exit 2 on a
+config error, 1 on a hub/fetch error or a dispatch that returned success:false, 0 otherwise.
+"""
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Optional
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+# E402: this import must follow the sys.path insert above so hubclient resolves when run as a script.
+from hubclient import HubError, _urllib_transport, resolve_base_from_args  # noqa: E402
+
+DEVICE_PATH = "/device/fullJson/"
+DEVICES_LIST_PATH = "/hub2/devicesList"
+RUNMETHOD_PATH = "/device/runmethod"
+
+# fullJson parameter types map onto these JSON arg kinds. ENUM constraints render as string in the
+# UI, so an ENUM value is sent as its literal string (rules/ui-automation.md, playwright-ui gotcha 34).
+_NUMBER_TYPES = {"NUMBER", "INTEGER"}
+_DECIMAL_TYPES = {"DECIMAL", "FLOAT", "NUMBER_DECIMAL"}
+
+
+def commands_of(full: dict) -> list:
+    """Pure. The device's command surface: fullJson `commands[]`, each a dict."""
+    return [c for c in (full.get("commands") or []) if isinstance(c, dict)]
+
+
+def command_names(commands: list) -> list:
+    """Pure. The declared command names, in order."""
+    return [str(c.get("name")) for c in commands if c.get("name") is not None]
+
+
+def find_command(commands: list, name: str) -> Optional[dict]:
+    """Pure. Exact-name match (command/method names are case-sensitive). None if absent."""
+    for c in commands:
+        if c.get("name") == name:
+            return c
+    return None
+
+
+def validate_command(commands: list, name: str) -> dict:
+    """Pure. Return the command entry, or raise HubError naming the valid commands. Rejecting an
+    unknown name against the real surface beats sending a method the driver does not implement."""
+    found = find_command(commands, name)
+    if found is None:
+        valid = ", ".join(command_names(commands)) or "(none declared)"
+        raise HubError(f"device has no command {name!r}. Valid commands: {valid}")
+    return found
+
+
+def coerce_arg(value: str, param_type: Optional[str]):
+    """Pure. Coerce one CLI string to its declared parameter type. NUMBER -> int (or float when the
+    literal is fractional); DECIMAL -> float; everything else (STRING, ENUM, unknown) -> the literal
+    string. Raises HubError on a numeric type that will not parse."""
+    kind = (param_type or "").upper()
+    if kind in _NUMBER_TYPES:
+        try:
+            return int(value)
+        except ValueError:
+            try:
+                return float(value)
+            except ValueError as e:
+                raise HubError(f"argument {value!r} is not a number (parameter type {param_type})") from e
+    if kind in _DECIMAL_TYPES:
+        try:
+            return float(value)
+        except ValueError as e:
+            raise HubError(f"argument {value!r} is not a decimal (parameter type {param_type})") from e
+    return value
+
+
+def parameter_types(command: dict) -> list:
+    """Pure. The declared parameter types of a command, in order ([] when none)."""
+    out = []
+    for p in command.get("parameters") or []:
+        if isinstance(p, dict):
+            out.append(p.get("type"))
+    return out
+
+
+def coerce_args(command: dict, raw_args: list) -> list:
+    """Pure. Map positional CLI args onto the command's parameter types and coerce each. More args
+    than declared parameters is an error (the command does not take them); an arg past the declared
+    list with no type would be an ambiguous send."""
+    types = parameter_types(command)
+    if len(raw_args) > len(types):
+        name = command.get("name")
+        raise HubError(
+            f"command {name!r} takes {len(types)} argument(s), got {len(raw_args)}: {raw_args!r}")
+    return [coerce_arg(value, types[i] if i < len(types) else None) for i, value in enumerate(raw_args)]
+
+
+def current_states(full: dict) -> dict:
+    """Pure. device.currentStates as {attribute_name: entry_dict}. {} when absent."""
+    device = full.get("device") or {}
+    states = device.get("currentStates")
+    out = {}
+    if isinstance(states, dict):
+        for name, entry in states.items():
+            if isinstance(entry, dict):
+                out[str(name)] = entry
+    elif isinstance(states, list):
+        for entry in states:
+            if isinstance(entry, dict) and entry.get("name") is not None:
+                out[str(entry["name"])] = entry
+    return out
+
+
+def related_attribute(command: dict) -> Optional[str]:
+    """Pure. The attribute a command is expected to move, per fullJson. None when unspecified."""
+    attr = command.get("relatedAttribute")
+    return str(attr) if attr else None
+
+
+def _state_value(entry: dict):
+    return entry.get("value") if isinstance(entry, dict) else None
+
+
+def _state_date(entry: dict):
+    return entry.get("date") if isinstance(entry, dict) else None
+
+
+def verify_outcome(before: dict, after: dict, attr: Optional[str]) -> dict:
+    """Pure. Compare an attribute's value across a before/after currentStates snapshot.
+
+    Result `changed` is True only when the value moved. An unchanged value is reported with
+    `note: "unchanged — command may have been a no-op (already in state), which the change filter
+    hides"`, never as a failure. A command with no relatedAttribute, or an attribute absent from the
+    surface, yields `changed: null` — the caller cannot confirm by observation and must fall back to
+    the event log (rules/state-vs-attributes.md)."""
+    if not attr:
+        return {"attribute": None, "changed": None,
+                "note": "command declares no relatedAttribute — confirm via /device/eventsJson"}
+    if attr not in before and attr not in after:
+        return {"attribute": attr, "changed": None,
+                "note": f"attribute {attr!r} not in currentStates — confirm via /device/eventsJson"}
+    before_val = _state_value(before.get(attr, {}))
+    after_val = _state_value(after.get(attr, {}))
+    changed = before_val != after_val
+    result = {
+        "attribute": attr,
+        "before": before_val,
+        "after": after_val,
+        "before_date": _state_date(before.get(attr, {})),
+        "after_date": _state_date(after.get(attr, {})),
+        "changed": changed,
+    }
+    if not changed:
+        result["note"] = ("unchanged — command may have been a no-op (already in state), which the "
+                          "change filter hides; confirm intent via /device/eventsJson if needed")
+    return result
+
+
+def parse_runmethod_response(text: str) -> dict:
+    """Pure. Parse the runmethod body `{"success":<bool>,"message":<str|null>}`. A non-JSON body
+    (an authed hub's HTML, a changed endpoint) raises HubError."""
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as e:
+        raise HubError(
+            f"/device/runmethod did not return JSON (got {text[:80]!r}). Check that Hub Security is "
+            f"off on this hub and that the endpoint is valid on its firmware.") from e
+    if not isinstance(payload, dict):
+        raise HubError(f"/device/runmethod returned {type(payload).__name__}, expected a JSON object")
+    return {"success": bool(payload.get("success")), "message": payload.get("message")}
+
+
+def fetch_full_json(base: str, device_id: int, transport=None) -> dict:
+    """GET /device/fullJson/<id>. Raises HubError on non-200 or non-JSON."""
+    transport = transport or _urllib_transport
+    url = base.rstrip("/") + DEVICE_PATH + str(device_id)
+    status, _, text = transport("GET", url, None)
+    if status != 200:
+        raise HubError(f"{url} returned HTTP {status} — check that {device_id} is a valid device id "
+                       f"and that Hub Security is off on this hub (an authed hub returns a "
+                       f"redirect/401 to the login page).")
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as e:
+        raise HubError(f"{url} did not return JSON (got {text[:80]!r}). Check that Hub Security is "
+                       f"off on this hub and that {device_id} is a device id.") from e
+
+
+def fetch_devices(base: str, transport=None) -> dict:
+    """GET /hub2/devicesList. Raises HubError on non-200 or non-JSON."""
+    transport = transport or _urllib_transport
+    url = base.rstrip("/") + DEVICES_LIST_PATH
+    status, _, text = transport("GET", url, None)
+    if status != 200:
+        raise HubError(f"{url} returned HTTP {status} — check that Hub Security is off on this hub.")
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as e:
+        raise HubError(f"{url} did not return JSON (got {text[:80]!r}). Check that Hub Security is "
+                       f"off on this hub.") from e
+
+
+def _walk_devices(entries) -> list:
+    """Pure. Flatten a /hub2/devicesList `devices` forest — a child appears only nested in its
+    parent's `children[]` (../_reference/parent-child-devices.md)."""
+    out = []
+    for entry in entries or []:
+        if not isinstance(entry, dict):
+            continue
+        out.append(entry)
+        out.extend(_walk_devices(entry.get("children")))
+    return out
+
+
+def resolve_device_id(devices_list: dict, name: str) -> int:
+    """Pure. Case-insensitive exact match of a device display name against /hub2/devicesList. Raises
+    HubError on zero or multiple matches so the caller never commands the wrong device."""
+    target = name.strip().lower()
+    matches = []
+    for entry in _walk_devices(devices_list.get("devices")):
+        data = entry.get("data") or {}
+        dev_name = data.get("name")
+        if dev_name is not None and str(dev_name).strip().lower() == target and data.get("id") is not None:
+            matches.append((int(data["id"]), str(dev_name)))
+    if not matches:
+        raise HubError(f"no device named {name!r} on this hub — check the exact display name "
+                       f"(the hub's Devices page), or pass --device <id>.")
+    if len(matches) > 1:
+        listed = ", ".join(f"{n!r} (id {i})" for i, n in matches)
+        raise HubError(f"{len(matches)} devices match name {name!r}: {listed}. Pass --device <id>.")
+    return matches[0][0]
+
+
+def run_method(base: str, device_id: int, method: str, args: list, transport=None) -> dict:
+    """POST /device/runmethod as JSON. Returns the parsed {success, message}. Raises HubError on a
+    non-200 or a non-JSON body."""
+    transport = transport or _urllib_transport
+    url = base.rstrip("/") + RUNMETHOD_PATH
+    body = json.dumps({"id": device_id, "method": method, "args": args})
+    status, _, text = transport("POST", url, body, "application/json")
+    if status != 200:
+        raise HubError(f"{url} returned HTTP {status} for {method!r} on device {device_id} — check "
+                       f"that Hub Security is off on this hub.")
+    return parse_runmethod_response(text)
+
+
+def describe_surface(commands: list) -> list:
+    """Pure. Project commands[] into a compact surface listing for --list."""
+    out = []
+    for c in commands:
+        out.append({
+            "name": c.get("name"),
+            "parameters": parameter_types(c),
+            "relatedAttribute": related_attribute(c),
+            "capability": bool(c.get("capability")),
+        })
+    return out
+
+
+def main(argv=None, transport=None) -> int:
+    p = argparse.ArgumentParser(
+        description="Run a command on a Hubitat device and confirm it landed by observation.")
+    sel = p.add_mutually_exclusive_group(required=True)
+    sel.add_argument("--device", type=int, help="device id to command")
+    sel.add_argument("--name", help="device display name to resolve to an id (exact match)")
+    p.add_argument("--command", help="command/method name (must exist in the device's command surface)")
+    p.add_argument("--arg", action="append", default=[], dest="args",
+                   help="positional command argument (repeatable, in order)")
+    p.add_argument("--list", action="store_true", help="print the device's command surface and exit")
+    p.add_argument("--no-verify", action="store_true",
+                   help="skip the post-command relatedAttribute re-read")
+    p.add_argument("--ip")
+    p.add_argument("--port", type=int, default=8080)
+    p.add_argument("--hub", help="named hub from hubs.json (when no --ip)")
+    p.add_argument("--hubs", help="path to hubs.json (default ./hubs.json when --hub is given)")
+    args = p.parse_args(argv)
+
+    if not args.list and not args.command:
+        print("--command is required unless --list is given", file=sys.stderr)
+        return 2
+
+    try:
+        base = resolve_base_from_args(ip=args.ip, port=args.port, hub=args.hub, hubs_path=args.hubs)
+    except HubError as e:
+        print(str(e), file=sys.stderr)
+        return 2
+
+    try:
+        device_id = args.device if args.device is not None else resolve_device_id(
+            fetch_devices(base, transport), args.name)
+        full = fetch_full_json(base, device_id, transport)
+        commands = commands_of(full)
+
+        if args.list:
+            print(json.dumps({"hub": base, "device_id": device_id,
+                              "commands": describe_surface(commands)}, indent=2, default=str))
+            return 0
+
+        command = validate_command(commands, args.command)
+        coerced = coerce_args(command, args.args)
+        attr = related_attribute(command)
+        verify = not args.no_verify
+        before = current_states(full) if verify else {}
+
+        response = run_method(base, device_id, args.command, coerced, transport)
+
+        verification = None
+        if verify:
+            after_full = fetch_full_json(base, device_id, transport)
+            verification = verify_outcome(before, current_states(after_full), attr)
+    except HubError as e:
+        print(str(e), file=sys.stderr)
+        return 1
+
+    result = {
+        "hub": base,
+        "device_id": device_id,
+        "command": args.command,
+        "args": coerced,
+        "dispatched": response["success"],
+        "response": response,
+        "verification": verification,
+    }
+    print(json.dumps(result, indent=2, default=str))
+    # success:false means the hub did not dispatch the method — a real failure, not a quiet no-op.
+    return 0 if response["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/_scripts/hubclient.py
+++ b/skills/_scripts/hubclient.py
@@ -98,12 +98,16 @@ def load_hubs(path) -> dict:
     return cfg
 
 
-def _urllib_transport(method: str, url: str, body: Optional[str]):
+def _urllib_transport(method: str, url: str, body: Optional[str], content_type: Optional[str] = None):
     """Default transport. Returns (status, headers_dict, text). The create POST 302-redirects
     to the new entry's editor URL (/app|driver/editor/<id>); urllib follows it, so the new id
-    is read from the final URL, surfaced here as a synthetic 'Location' header."""
+    is read from the final URL, surfaced here as a synthetic 'Location' header.
+
+    `content_type` overrides the request Content-Type for a body; it defaults to
+    form-urlencoded (the code endpoints), and callers that POST JSON (e.g. /device/runmethod)
+    pass "application/json"."""
     data = body.encode() if body is not None else None
-    headers = {"Content-Type": "application/x-www-form-urlencoded"} if data else {}
+    headers = {"Content-Type": content_type or "application/x-www-form-urlencoded"} if data else {}
     req = urllib.request.Request(url, data=data, headers=headers, method=method)
     try:
         resp = urllib.request.urlopen(req, timeout=15)

--- a/skills/_scripts/tests/test_hub_device_command.py
+++ b/skills/_scripts/tests/test_hub_device_command.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Tests for skills/_scripts/hub_device_command.py — pure command-surface validation, argument
+coercion, currentStates diffing, runmethod response parsing, plus the fetch/run error paths and the
+main() flow with an injected transport. No live hub.
+
+Fixtures mirror the live shapes on 2.5.1.134–135 (C-8 Pro): fullJson `commands[]` entries carry
+{name, parameters:[{type}], relatedAttribute, capability}; device.currentStates is a dict keyed by
+attribute; /device/runmethod answers {"success":<bool>,"message":<str|null>}."""
+
+import importlib.util
+import json
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent.parent / "hub_device_command.py"
+spec = importlib.util.spec_from_file_location("hub_device_command", SCRIPT)
+assert spec and spec.loader
+m = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(m)
+HubError = m.HubError
+
+
+def cmd(name, params=None, related=None, capability=True):
+    return {"name": name, "parameters": [{"type": t} for t in (params or [])],
+            "relatedAttribute": related, "capability": capability}
+
+
+def full_json(commands=None, states=None):
+    return {
+        "device": {"id": 1639, "name": "Generic Zigbee Switch", "displayName": "Zone 8 Soil",
+                   "currentStates": states or {}},
+        "commands": commands if commands is not None else [
+            cmd("on", related="switch"), cmd("off", related="switch"),
+            cmd("setLevel", params=["NUMBER", "NUMBER"], related="level"),
+            cmd("setZoneWaterTime", params=["NUMBER"], related=None, capability=False),
+        ],
+    }
+
+
+class FakeTransport:
+    """Records calls and returns queued (status, headers, text) responses by (method, path)."""
+    def __init__(self, responses):
+        self._responses = responses  # {(method, path_suffix): (status, text)}
+        self.calls = []
+
+    def __call__(self, method, url, body, content_type=None):
+        self.calls.append({"method": method, "url": url, "body": body, "content_type": content_type})
+        for (want_method, suffix), (status, text) in self._responses.items():
+            if method == want_method and url.endswith(suffix):
+                return status, {}, text
+        raise AssertionError(f"unexpected transport call {method} {url}")
+
+
+class TestCommandSurface(unittest.TestCase):
+    def test_commands_of_filters_non_dicts(self):
+        self.assertEqual(len(m.commands_of({"commands": [cmd("on"), "junk", None]})), 1)
+
+    def test_command_names_in_order(self):
+        self.assertEqual(m.command_names(m.commands_of(full_json())),
+                         ["on", "off", "setLevel", "setZoneWaterTime"])
+
+    def test_find_command_exact_case_sensitive(self):
+        cmds = m.commands_of(full_json())
+        self.assertIsNotNone(m.find_command(cmds, "setLevel"))
+        self.assertIsNone(m.find_command(cmds, "setlevel"))
+
+    def test_validate_unknown_lists_valid(self):
+        cmds = m.commands_of(full_json())
+        with self.assertRaises(HubError) as ctx:
+            m.validate_command(cmds, "nope")
+        msg = str(ctx.exception)
+        self.assertIn("nope", msg)
+        self.assertIn("setZoneWaterTime", msg)
+
+    def test_describe_surface_marks_custom_command(self):
+        surface = {s["name"]: s for s in m.describe_surface(m.commands_of(full_json()))}
+        self.assertFalse(surface["setZoneWaterTime"]["capability"])
+        self.assertTrue(surface["on"]["capability"])
+        self.assertEqual(surface["setLevel"]["parameters"], ["NUMBER", "NUMBER"])
+
+
+class TestArgCoercion(unittest.TestCase):
+    def test_number_int_and_float(self):
+        self.assertEqual(m.coerce_arg("40", "NUMBER"), 40)
+        self.assertIsInstance(m.coerce_arg("40", "NUMBER"), int)
+        self.assertEqual(m.coerce_arg("40.5", "NUMBER"), 40.5)
+
+    def test_decimal(self):
+        self.assertEqual(m.coerce_arg("1.5", "DECIMAL"), 1.5)
+
+    def test_string_and_enum_pass_through(self):
+        self.assertEqual(m.coerce_arg("false", "ENUM"), "false")
+        self.assertEqual(m.coerce_arg("open", "STRING"), "open")
+
+    def test_bad_number_raises(self):
+        with self.assertRaises(HubError):
+            m.coerce_arg("high", "NUMBER")
+
+    def test_coerce_args_maps_positional_types(self):
+        command = cmd("setLevel", params=["NUMBER", "NUMBER"])
+        self.assertEqual(m.coerce_args(command, ["40", "5"]), [40, 5])
+
+    def test_too_many_args_raises(self):
+        with self.assertRaises(HubError):
+            m.coerce_args(cmd("on"), ["40"])
+
+    def test_extra_untyped_arg_is_string(self):
+        # a command declaring one param, given one arg, coerces that one; count guard covers overflow
+        self.assertEqual(m.coerce_args(cmd("setZoneWaterTime", params=["NUMBER"]), ["10"]), [10])
+
+
+class TestCurrentStates(unittest.TestCase):
+    def test_dict_shape(self):
+        states = m.current_states(full_json(states={"switch": {"value": "on", "date": "d1"}}))
+        self.assertEqual(states["switch"]["value"], "on")
+
+    def test_list_shape(self):
+        states = m.current_states({"device": {"currentStates": [{"name": "level", "value": 40}]}})
+        self.assertEqual(states["level"]["value"], 40)
+
+    def test_absent(self):
+        self.assertEqual(m.current_states({"device": {}}), {})
+
+
+class TestVerifyOutcome(unittest.TestCase):
+    def test_changed(self):
+        r = m.verify_outcome({"switch": {"value": "off"}}, {"switch": {"value": "on"}}, "switch")
+        self.assertTrue(r["changed"])
+        self.assertEqual((r["before"], r["after"]), ("off", "on"))
+
+    def test_unchanged_is_not_failure(self):
+        r = m.verify_outcome({"switch": {"value": "on"}}, {"switch": {"value": "on"}}, "switch")
+        self.assertFalse(r["changed"])
+        self.assertIn("no-op", r["note"])
+
+    def test_no_related_attribute(self):
+        r = m.verify_outcome({}, {}, None)
+        self.assertIsNone(r["changed"])
+        self.assertIn("eventsJson", r["note"])
+
+    def test_attribute_absent(self):
+        r = m.verify_outcome({"switch": {"value": "on"}}, {"switch": {"value": "on"}}, "level")
+        self.assertIsNone(r["changed"])
+
+
+class TestRunmethodResponse(unittest.TestCase):
+    def test_success(self):
+        self.assertEqual(m.parse_runmethod_response('{"success":true,"message":null}'),
+                         {"success": True, "message": None})
+
+    def test_failure_flag(self):
+        self.assertFalse(m.parse_runmethod_response('{"success":false,"message":"boom"}')["success"])
+
+    def test_non_json_raises(self):
+        with self.assertRaises(HubError):
+            m.parse_runmethod_response("<html>login</html>")
+
+
+class TestRunMethodTransport(unittest.TestCase):
+    def test_posts_json_body_with_content_type(self):
+        t = FakeTransport({("POST", "/device/runmethod"): (200, '{"success":true,"message":null}')})
+        out = m.run_method("http://h:8080", 1639, "setLevel", [40, 5], t)
+        self.assertTrue(out["success"])
+        call = t.calls[0]
+        self.assertEqual(call["content_type"], "application/json")
+        self.assertEqual(json.loads(call["body"]), {"id": 1639, "method": "setLevel", "args": [40, 5]})
+
+    def test_non_200_raises(self):
+        t = FakeTransport({("POST", "/device/runmethod"): (404, "")})
+        with self.assertRaises(HubError):
+            m.run_method("http://h:8080", 1, "on", [], t)
+
+
+class TestResolveDeviceId(unittest.TestCase):
+    def test_exact_case_insensitive(self):
+        devices = {"devices": [{"data": {"id": 1639, "name": "Zone 8 Soil"}}]}
+        self.assertEqual(m.resolve_device_id(devices, "zone 8 soil"), 1639)
+
+    def test_zero_matches_raises(self):
+        with self.assertRaises(HubError):
+            m.resolve_device_id({"devices": []}, "nope")
+
+    def test_multiple_matches_raises(self):
+        devices = {"devices": [{"data": {"id": 1, "name": "Dup"}}, {"data": {"id": 2, "name": "Dup"}}]}
+        with self.assertRaises(HubError):
+            m.resolve_device_id(devices, "Dup")
+
+
+class TestMain(unittest.TestCase):
+    def test_list_prints_surface_and_runs_nothing(self):
+        t = FakeTransport({("GET", "/device/fullJson/1639"): (200, json.dumps(full_json()))})
+        import contextlib
+        import io
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            rc = m.main(["--ip", "192.0.2.11", "--device", "1639", "--list"], t)
+        self.assertEqual(rc, 0)
+        out = json.loads(buf.getvalue())
+        self.assertEqual([c["name"] for c in out["commands"]],
+                         ["on", "off", "setLevel", "setZoneWaterTime"])
+        self.assertTrue(all(c["method"] == "GET" for c in t.calls))  # no runmethod POST
+
+    def test_command_dispatch_and_verify_change(self):
+        before = full_json(states={"switch": {"value": "off", "date": "d0"}})
+        after = full_json(states={"switch": {"value": "on", "date": "d1"}})
+        t = FakeTransport({
+            ("GET", "/device/fullJson/1639"): (200, json.dumps(before)),
+            ("POST", "/device/runmethod"): (200, '{"success":true,"message":null}'),
+        })
+        # second fullJson (post-command) must reflect the change: swap the GET response mid-run
+        calls = {"n": 0}
+        original = t.__call__
+
+        def sequenced(method, url, body, content_type=None):
+            if method == "GET" and url.endswith("/device/fullJson/1639"):
+                calls["n"] += 1
+                payload = before if calls["n"] == 1 else after
+                t.calls.append({"method": method, "url": url, "body": body, "content_type": content_type})
+                return 200, {}, json.dumps(payload)
+            return original(method, url, body, content_type)
+
+        import contextlib
+        import io
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            rc = m.main(["--ip", "192.0.2.11", "--device", "1639", "--command", "on"], sequenced)
+        self.assertEqual(rc, 0)
+        out = json.loads(buf.getvalue())
+        self.assertTrue(out["dispatched"])
+        self.assertTrue(out["verification"]["changed"])
+
+    def test_unknown_command_exits_1(self):
+        t = FakeTransport({("GET", "/device/fullJson/1639"): (200, json.dumps(full_json()))})
+        import contextlib
+        import io
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            rc = m.main(["--ip", "192.0.2.11", "--device", "1639", "--command", "nope"], t)
+        self.assertEqual(rc, 1)
+        self.assertIn("no command", err.getvalue())
+
+    def test_dispatch_false_exits_1(self):
+        t = FakeTransport({
+            ("GET", "/device/fullJson/1639"): (200, json.dumps(full_json())),
+            ("POST", "/device/runmethod"): (200, '{"success":false,"message":"threw"}'),
+        })
+        import contextlib
+        import io
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            rc = m.main(["--ip", "192.0.2.11", "--device", "1639", "--command", "on", "--no-verify"], t)
+        self.assertEqual(rc, 1)
+        self.assertFalse(json.loads(buf.getvalue())["dispatched"])
+
+    def test_command_required_unless_list(self):
+        import contextlib
+        import io
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            rc = m.main(["--ip", "192.0.2.11", "--device", "1639"], None)
+        self.assertEqual(rc, 2)
+        self.assertIn("--command is required", err.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/device-command/SKILL.md
+++ b/skills/device-command/SKILL.md
@@ -25,7 +25,7 @@ python3 .tessl/plugins/jbaruch/hubitat-dev/skills/_scripts/hub_device_command.py
 
 Output is one JSON object listing each command's `name`, `parameters` (declared types, in order), `relatedAttribute`, and `capability` (false marks a driver custom command). Match the intended command and its argument types against this list — `setZoneWaterTime` takes a number, and a string fails oddly. The run in Step 3 rejects a name absent from this surface. Proceed to Step 3.
 
-## Step 3 — Run the command and verify
+## Step 3 — Run the command
 
 ```
 python3 .tessl/plugins/jbaruch/hubitat-dev/skills/_scripts/hub_device_command.py --ip <addr> --device <id> --command <name> [--arg <v> ...]

--- a/skills/device-command/SKILL.md
+++ b/skills/device-command/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: device-command
+description: Run a command on a Hubitat device over HTTP and confirm it landed — turn a switch or plug on/off, set a dimmer level, refresh a sensor, start an irrigation zone, or run a driver's custom command. Use when the user wants to command, control, operate, or exercise a device, test that a device responds, or run a device command and verify it took effect. Not for deleting a device (that is device-removal).
+---
+
+# Device-Command Skill
+
+Process steps in order. Do not skip ahead.
+
+Commanding a device is the "make the thing do the thing, then observe it" half of field diagnosis. The hub exposes each device's real command surface and runs a command over one undocumented endpoint; `hub_device_command.py` enumerates the surface, sends the command, and re-reads the result. This skill frames the command and interprets the outcome.
+
+**A command's return code is not evidence it executed.** The hub answers `{"success":true}` when the Groovy method is *dispatched*, not when the device moved — a method that throws, or a command to the state the device is already in, returns the identical payload (`rules/state-vs-attributes.md`). Step 4 is what earns "it worked."
+
+## Step 1 — Frame the command
+
+Establish the hub (`--ip <addr>` or `--hub <name>`), the device (`--device <id>` or `--name "<exact display name>"`), and the command with any arguments. This runs over HTTP with Hub Security off (`skills/_reference/endpoints.md`). Commanding a **physical** device has real-world side effects — a valve, a lock, a garage door, lights. Confirm the device and command with the user before running one whose effect is physical and consequential. Proceed to Step 2.
+
+## Step 2 — Enumerate the command surface
+
+Read the device's real commands before sending one:
+
+```
+python3 .tessl/plugins/jbaruch/hubitat-dev/skills/_scripts/hub_device_command.py --ip <addr> --device <id> --list
+```
+
+Output is one JSON object listing each command's `name`, `parameters` (declared types, in order), `relatedAttribute`, and `capability` (false marks a driver custom command). Match the intended command and its argument types against this list — `setZoneWaterTime` takes a number, and a string fails oddly. The run in Step 3 rejects a name absent from this surface. Proceed to Step 3.
+
+## Step 3 — Run the command and verify
+
+```
+python3 .tessl/plugins/jbaruch/hubitat-dev/skills/_scripts/hub_device_command.py --ip <addr> --device <id> --command <name> [--arg <v> ...]
+```
+
+Argument contract, exit codes, and output shape: `skills/_scripts/hub_device_command.py` module docstring. The script validates the command against the surface, coerces each `--arg` to its declared type, POSTs `/device/runmethod`, then re-reads the command's `relatedAttribute` from `currentStates` and reports whether it moved. `--arg` is repeatable and positional. Proceed to Step 4.
+
+## Step 4 — Interpret the result
+
+Read the output object, not the exit code alone:
+
+- `dispatched: true` means the hub ran the method, never that the device changed. `dispatched: false` is a real failure — the method threw or the endpoint refused (exit 1).
+- `verification.changed: true` — the `relatedAttribute` moved; the command took effect.
+- `verification.changed: false` — unchanged, and **not** a failure. Commanding a device to the state it is already in produces no event (the change filter, `rules/state-vs-attributes.md`). Re-run against a different target state, or confirm the command was issued via `GET /device/eventsJson/<id>` with `Skill(skill: "debug")`.
+- `verification.changed: null` — the command declares no `relatedAttribute`, or the attribute is absent from the surface. Confirm through the event log rather than the command response.
+
+Report what was commanded, whether it dispatched, and whether the attribute moved. Finish here.


### PR DESCRIPTION
**PR 4 of ~6 for #78** — the first new *skill*, closing the "make the thing do the thing, then observe it" gap. The command-execution route (`POST /device/runmethod`) was documented in PR1; this builds the skill on top of it.

## `skills/_scripts/hub_device_command.py` (+ 32 tests)
- Enumerates the authoritative command surface from `fullJson.commands[]` — rejects an unknown command name with the valid list, including driver **custom** commands (`capability:false`) that inferring from the declared capability would miss.
- Coerces each `--arg` to its declared `parameters[].type` (`setZoneWaterTime` takes a number).
- POSTs `/device/runmethod` as JSON, then re-reads the command's `relatedAttribute` from `currentStates`.
- **Verify by observation, not response code:** `{"success":true}` = *dispatched, not executed*. A throwing method or a command to the already-current state returns the identical payload, and the change filter hides the no-op — so an unchanged attribute is reported as `unchanged`, never as failure (confirm via `eventsJson`).
- `--list` prints the surface and runs nothing; `--name` resolves by exact display name.

## `skills/device-command/SKILL.md`
Sequential workflow: frame → enumerate surface (`--list`) → run + verify → interpret (`dispatched` vs `changed`). Guards physical side effects; points at `debug`/`eventsJson` for the no-relatedAttribute case.

## Infra
- `hubclient._urllib_transport` gains an optional `content_type` (JSON for `runmethod`), backward-compatible with the form-encoded code endpoints.
- README skills table, `_scripts/README.md`, CHANGELOG synced; skill auto-included via the `skills/` glob.

## Verification
- `pyright` 0 errors; **281 unit tests pass** (32 new, no live hub); `tessl plugin lint` ✔.
- Note: `tessl review run` is currently **credit-blocked (403)**; CI's `skill-review` is set `credit-outage: skip` (the documented carve-out), so it publishes flagged-unreviewed rather than blocking. Every other CI check still gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)