### PR TITLE
feat(device-sequence): timed ordered device walk to map physical devices (#78)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Added
+
+- **New skill `device-sequence` — fire an ordered list of devices with a timed hold on each** (`skills/device-sequence/SKILL.md`, `skills/_scripts/hub_device_sequence.py` + tests, `skills/device-command/SKILL.md`, `README.md`, part of #78). The "which physical thing does this device control?" primitive: walk the property while zones (or lamps, shades, valves) activate in a known order, so every photo or observation binds to a device id instead of a guess. Built on `device-command` — each command is validated against that device's real surface and dispatched over `/device/runmethod` — adding the ordered walk, the per-device timed hold (so the operator can reach and observe), live per-step narration to stderr, and an optional `--off-command` run after each hold. A device that fails to dispatch is skipped without a hold, and the walk continues rather than aborting. Confirmation is the operator observing during the hold, not a return code (`rules/state-vs-attributes.md`). Deterministic core (id parsing, plan building, aggregation) is unit-tested with an injected transport, a no-op sleeper, and a capturing narrator (14 tests, no live hub or real clock). `device-command` Step 4 now cross-references this skill; both auto-included via the `skills/` glob.
+
 ## 0.1.50 — 2026-07-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ All rules are always-on — installing the plugin means you want this context.
 | [test](skills/test/SKILL.md) | Setting up offline unit tests (biocomp/hubitat_ci) so logic is exercised off-hub. |
 | [hub-config](skills/hub-config/SKILL.md) | Managing `hubs.json` — register, list, and set the default hub (action router). |
 | [device-command](skills/device-command/SKILL.md) | Running a command on a device over HTTP and confirming it landed — enumerate the real command surface, send it, and verify by re-reading the related attribute (dispatched ≠ executed). |
+| [device-sequence](skills/device-sequence/SKILL.md) | Firing an ordered list of devices with a timed hold on each — walk the property and bind each photo or observation to a device id (which lamp/shade/valve/zone is which). |
 | [device-removal](skills/device-removal/SKILL.md) | Safely removing a device — enumerate usage, warn on blast radius, verify after, and restore references onto a replacement. |
 | [device-migration](skills/device-migration/SKILL.md) | Moving every app reference from an old device to a new one — Swap Device, a virtual bridge/parking slot, a Hub Mesh re-home across hubs, or a guided manual re-select, chosen by why the swap is blocked. |
 

--- a/skills/_scripts/README.md
+++ b/skills/_scripts/README.md
@@ -21,6 +21,7 @@ end-of-life on 2024-10-07; CI runs 3.11.
 | `hub_radiolog.py` | Tail the `zwaveLogsocket`/`zigbeeLogsocket` for per-frame radio traffic | WebSocket |
 | `hub_device_usage.py` | Report a device's delete blast radius; `--live` audits subscriptions and Rule Machine `trigDevs` separately | HTTP |
 | `hub_device_command.py` | Run a command on a device (enumerate the real command surface, coerce args, POST `runmethod`) and verify it landed by re-reading the `relatedAttribute` | HTTP |
+| `hub_device_sequence.py` | Fire an ordered list of devices with a timed hold on each (built on `hub_device_command`); live per-step narration for a field walk that binds observations to device ids | HTTP |
 | `hub_fw_update.py` | Batch-flash Z-Wave firmware via the native zwaveJS updater, with a no-progress watchdog, canary radio-health probe + auto-reboot recovery, and an RSSI floor (a failed/stalled OTA can hang the whole controller) | HTTP |
 | `hubs_config.py` | Owner of `hubs.json` — init/add/set-default/remove/list hubs (imported + CLI) | — |
 

--- a/skills/_scripts/hub_device_sequence.py
+++ b/skills/_scripts/hub_device_sequence.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Fire an ordered list of Hubitat devices with a timed hold on each — the "which physical thing
+does this device control?" primitive.
+
+Walk the property while zones (or lamps, shades, valves) activate in a known order, so every photo
+or observation binds definitively to a device id instead of a guess. Generalizes past irrigation:
+which lamp is `Kitchen 3`, which shade is `Office Left`, which valve is zone 7.
+
+Per device, in order: announce the step, run a command (default `on`) over `/device/runmethod`, hold
+for `--duration` seconds so the person in the field can observe, then optionally run an off command
+(e.g. `off`) before the next device. Built on the device-command primitives — each command is
+validated against that device's real surface and each argument coerced to its declared type
+(see hub_device_command.py; ../_reference/endpoints.md).
+
+The command is *dispatched*, not proven executed (rules/state-vs-attributes.md) — this script reports
+per-step dispatch and leaves confirmation-by-observation to the operator in the field, which is the
+whole point of the timed hold.
+
+The deterministic pieces (id parsing, plan building, result aggregation) are pure and unit-tested;
+the network (`transport`), the hold (`sleeper`), and the live narration (`announce`) are injected so
+the sequence runs without a hub, a real clock, or real output in tests.
+
+Usage:
+    hub_device_sequence.py --ip 192.0.2.11 --devices 1639,1640,1641 --duration 120
+    hub_device_sequence.py --ip 192.0.2.11 --devices 12,13 --command on --off-command off --duration 90
+    hub_device_sequence.py --hub main --devices 1639,1640 --command push --arg 1 --duration 30
+Output: one JSON object on stdout ({hub, command, steps:[...], summary}). Live per-step narration
+goes to stderr. Exit 2 on a config/usage error, 1 when any step failed to dispatch, 0 otherwise.
+"""
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+# E402: imports must follow the sys.path insert so the sibling modules resolve when run as a script.
+from hubclient import HubError, resolve_base_from_args  # noqa: E402
+from hub_device_command import (  # noqa: E402
+    coerce_args, commands_of, fetch_devices, fetch_full_json, resolve_device_id, run_method,
+    validate_command,
+)
+
+
+def parse_device_ids(raw: str) -> list:
+    """Pure. Parse a comma-separated device-id list ('1639,1640') into ordered ints. Raises HubError
+    on an empty list or a non-integer token — a sequence with a bad id would fire the wrong device."""
+    tokens = [t.strip() for t in (raw or "").split(",") if t.strip()]
+    if not tokens:
+        raise HubError("--devices is empty — give a comma-separated list of device ids in order")
+    ids = []
+    for token in tokens:
+        try:
+            ids.append(int(token))
+        except ValueError as e:
+            raise HubError(f"device id {token!r} in --devices is not an integer") from e
+    return ids
+
+
+def build_plan(device_ids: list, command: str, args: list, duration: float,
+               off_command=None) -> list:
+    """Pure. Build the ordered step plan. Each step names the device, the command and its args, the
+    hold duration, and the optional off command run before the next device."""
+    total = len(device_ids)
+    return [
+        {
+            "index": i + 1,
+            "total": total,
+            "device_id": device_id,
+            "command": command,
+            "args": args,
+            "duration": duration,
+            "off_command": off_command,
+        }
+        for i, device_id in enumerate(device_ids)
+    ]
+
+
+def summarize(steps: list) -> dict:
+    """Pure. Roll step results into counts."""
+    dispatched = sum(1 for s in steps if s.get("dispatched"))
+    failed = [s for s in steps if s.get("error") or s.get("dispatched") is False]
+    return {"total": len(steps), "dispatched": dispatched, "failed": len(failed)}
+
+
+def _run_one(base: str, step: dict, transport, announce) -> dict:
+    """Run a single device's command and (optionally) its off command. Returns the step result.
+    A per-device failure is captured, never raised — one unreachable device must not abort the walk."""
+    device_id = step["device_id"]
+    result = dict(step)
+    try:
+        full = fetch_full_json(base, device_id, transport)
+        commands = commands_of(full)
+        device_name = (full.get("device") or {}).get("displayName") or str(device_id)
+        result["device_name"] = device_name
+
+        command = validate_command(commands, step["command"])
+        coerced = coerce_args(command, step["args"])
+        announce(f"[{step['index']}/{step['total']}] {device_name}: {step['command']} "
+                 f"{coerced if coerced else ''}".rstrip())
+        response = run_method(base, device_id, step["command"], coerced, transport)
+        result["args"] = coerced
+        result["dispatched"] = response["success"]
+        if not response["success"]:
+            result["error"] = f"runmethod returned success:false ({response.get('message')})"
+    except HubError as e:
+        result["dispatched"] = False
+        result["error"] = str(e)
+        announce(f"[{step['index']}/{step['total']}] device {device_id}: FAILED — {e}")
+    return result
+
+
+def _run_off(base: str, step: dict, result: dict, transport, announce) -> None:
+    """Run the optional off command for a step after its hold. Best-effort; records off_error."""
+    if not step.get("off_command"):
+        return
+    device_id = step["device_id"]
+    try:
+        full = fetch_full_json(base, device_id, transport)
+        command = validate_command(commands_of(full), step["off_command"])
+        run_method(base, device_id, step["off_command"], coerce_args(command, []), transport)
+        result["off_dispatched"] = True
+    except HubError as e:
+        result["off_dispatched"] = False
+        result["off_error"] = str(e)
+        announce(f"[{step['index']}/{step['total']}] device {device_id}: off '{step['off_command']}' "
+                 f"FAILED — {e}")
+
+
+def run_sequence(base: str, plan: list, transport=None, sleeper=None, announce=None) -> list:
+    """Execute the plan in order. `transport` is the hub HTTP callable, `sleeper(seconds)` performs
+    the hold (injected so tests do not wait), `announce(text)` narrates live (stderr by default).
+    Returns the per-step results. A step that fails to dispatch is skipped without a hold — nothing
+    fired, so there is nothing to observe."""
+    sleeper = sleeper or time.sleep
+    announce = announce or (lambda text: print(text, file=sys.stderr))
+    results = []
+    for step in plan:
+        result = _run_one(base, step, transport, announce)
+        if result.get("dispatched"):
+            if step["duration"]:
+                announce(f"    holding {step['duration']}s...")
+                sleeper(step["duration"])
+            _run_off(base, step, result, transport, announce)
+        results.append(result)
+    return results
+
+
+def _resolve_ids(base, args, transport):
+    """Resolve --devices ids, or --names (comma-separated display names) in order."""
+    if args.devices:
+        return parse_device_ids(args.devices)
+    devices_list = fetch_devices(base, transport)
+    names = [n.strip() for n in args.names.split(",") if n.strip()]
+    if not names:
+        raise HubError("--names is empty — give a comma-separated list of device names in order")
+    return [resolve_device_id(devices_list, name) for name in names]
+
+
+def main(argv=None, transport=None, sleeper=None) -> int:
+    p = argparse.ArgumentParser(
+        description="Fire an ordered list of Hubitat devices with a timed hold on each.")
+    sel = p.add_mutually_exclusive_group(required=True)
+    sel.add_argument("--devices", help="comma-separated device ids, in order (e.g. 1639,1640,1641)")
+    sel.add_argument("--names", help="comma-separated device display names, in order")
+    p.add_argument("--command", default="on", help="command to run on each device (default: on)")
+    p.add_argument("--arg", action="append", default=[], dest="args",
+                   help="positional argument for the command (repeatable)")
+    p.add_argument("--off-command", dest="off_command",
+                   help="command to run on each device after its hold (e.g. off)")
+    p.add_argument("--duration", type=float, default=60.0,
+                   help="seconds to hold each device before the next (default: 60)")
+    p.add_argument("--ip")
+    p.add_argument("--port", type=int, default=8080)
+    p.add_argument("--hub", help="named hub from hubs.json (when no --ip)")
+    p.add_argument("--hubs", help="path to hubs.json (default ./hubs.json when --hub is given)")
+    args = p.parse_args(argv)
+
+    try:
+        base = resolve_base_from_args(ip=args.ip, port=args.port, hub=args.hub, hubs_path=args.hubs)
+    except HubError as e:
+        print(str(e), file=sys.stderr)
+        return 2
+
+    try:
+        device_ids = _resolve_ids(base, args, transport)
+    except HubError as e:
+        print(str(e), file=sys.stderr)
+        return 2
+
+    plan = build_plan(device_ids, args.command, args.args, args.duration, args.off_command)
+    steps = run_sequence(base, plan, transport, sleeper)
+    summary = summarize(steps)
+    print(json.dumps({"hub": base, "command": args.command, "steps": steps, "summary": summary},
+                     indent=2, default=str))
+    return 0 if summary["failed"] == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/_scripts/hub_device_sequence.py
+++ b/skills/_scripts/hub_device_sequence.py
@@ -77,9 +77,11 @@ def build_plan(device_ids: list, command: str, args: list, duration: float,
 
 
 def summarize(steps: list) -> dict:
-    """Pure. Roll step results into counts."""
+    """Pure. Roll step results into counts. A step counts as failed when its command did not dispatch
+    or its optional off command failed (off_dispatched is False)."""
     dispatched = sum(1 for s in steps if s.get("dispatched"))
-    failed = [s for s in steps if s.get("error") or s.get("dispatched") is False]
+    failed = [s for s in steps
+              if s.get("error") or s.get("dispatched") is False or s.get("off_dispatched") is False]
     return {"total": len(steps), "dispatched": dispatched, "failed": len(failed)}
 
 
@@ -118,8 +120,13 @@ def _run_off(base: str, step: dict, result: dict, transport, announce) -> None:
     try:
         full = fetch_full_json(base, device_id, transport)
         command = validate_command(commands_of(full), step["off_command"])
-        run_method(base, device_id, step["off_command"], coerce_args(command, []), transport)
-        result["off_dispatched"] = True
+        response = run_method(base, device_id, step["off_command"], coerce_args(command, []), transport)
+        result["off_dispatched"] = response["success"]
+        if not response["success"]:
+            result["off_error"] = (f"off '{step['off_command']}' returned success:false "
+                                   f"({response.get('message')})")
+            announce(f"[{step['index']}/{step['total']}] device {device_id}: off "
+                     f"'{step['off_command']}' returned success:false")
     except HubError as e:
         result["off_dispatched"] = False
         result["off_error"] = str(e)
@@ -175,6 +182,11 @@ def main(argv=None, transport=None, sleeper=None) -> int:
     p.add_argument("--hub", help="named hub from hubs.json (when no --ip)")
     p.add_argument("--hubs", help="path to hubs.json (default ./hubs.json when --hub is given)")
     args = p.parse_args(argv)
+
+    if args.duration < 0:
+        print(f"--duration must be >= 0 seconds (got {args.duration}) — a negative hold is not a "
+              f"valid sleep", file=sys.stderr)
+        return 2
 
     try:
         base = resolve_base_from_args(ip=args.ip, port=args.port, hub=args.hub, hubs_path=args.hubs)

--- a/skills/_scripts/tests/test_hub_device_sequence.py
+++ b/skills/_scripts/tests/test_hub_device_sequence.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Tests for skills/_scripts/hub_device_sequence.py — pure id parsing, plan building, and result
+summarizing, plus run_sequence and main() with an injected transport, a no-op sleeper, and a
+capturing announce. No live hub, no real clock."""
+
+import importlib.util
+import json
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent.parent / "hub_device_sequence.py"
+spec = importlib.util.spec_from_file_location("hub_device_sequence", SCRIPT)
+assert spec and spec.loader
+m = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(m)
+HubError = m.HubError
+
+
+def full_json(device_id=1639, name="Zone 8 Soil", commands=None):
+    return {
+        "device": {"id": device_id, "displayName": name, "currentStates": {}},
+        "commands": commands if commands is not None else [
+            {"name": "on", "parameters": [], "relatedAttribute": "switch", "capability": True},
+            {"name": "off", "parameters": [], "relatedAttribute": "switch", "capability": True},
+        ],
+    }
+
+
+class FakeTransport:
+    """Serves GET /device/fullJson/<id> and POST /device/runmethod. runmethod success is keyed by
+    device id via `fail_ids`."""
+    def __init__(self, devices, fail_ids=()):
+        self.devices = devices  # {id: full_json}
+        self.fail_ids = set(fail_ids)
+        self.runmethod_calls = []
+
+    def __call__(self, method, url, body, _content_type=None):
+        if method == "GET" and "/device/fullJson/" in url:
+            did = int(url.rsplit("/", 1)[1])
+            if did in self.devices:
+                return 200, {}, json.dumps(self.devices[did])
+            return 404, {}, ""
+        if method == "POST" and url.endswith("/device/runmethod"):
+            payload = json.loads(body)
+            self.runmethod_calls.append(payload)
+            ok = payload["id"] not in self.fail_ids
+            return 200, {}, json.dumps({"success": ok, "message": None if ok else "threw"})
+        raise AssertionError(f"unexpected call {method} {url}")
+
+
+class TestParseDeviceIds(unittest.TestCase):
+    def test_ordered_ints(self):
+        self.assertEqual(m.parse_device_ids("1639, 1640 ,1641"), [1639, 1640, 1641])
+
+    def test_empty_raises(self):
+        with self.assertRaises(HubError):
+            m.parse_device_ids("  ")
+
+    def test_non_integer_raises(self):
+        with self.assertRaises(HubError):
+            m.parse_device_ids("1639,zone2")
+
+
+class TestBuildPlan(unittest.TestCase):
+    def test_indices_and_total(self):
+        plan = m.build_plan([10, 11], "on", [], 30.0, off_command="off")
+        self.assertEqual([s["index"] for s in plan], [1, 2])
+        self.assertTrue(all(s["total"] == 2 for s in plan))
+        self.assertEqual(plan[0]["off_command"], "off")
+        self.assertEqual(plan[1]["device_id"], 11)
+
+
+class TestSummarize(unittest.TestCase):
+    def test_counts(self):
+        steps = [{"dispatched": True}, {"dispatched": False, "error": "x"}, {"dispatched": True}]
+        self.assertEqual(m.summarize(steps), {"total": 3, "dispatched": 2, "failed": 1})
+
+
+class TestRunSequence(unittest.TestCase):
+    def setUp(self):
+        self.slept = []
+        self.announced = []
+
+    def _sleeper(self, seconds):
+        self.slept.append(seconds)
+
+    def _announce(self, text):
+        self.announced.append(text)
+
+    def test_runs_each_in_order_and_holds(self):
+        t = FakeTransport({10: full_json(10, "A"), 11: full_json(11, "B")})
+        plan = m.build_plan([10, 11], "on", [], 5.0)
+        results = m.run_sequence("http://h:8080", plan, t, self._sleeper, self._announce)
+        self.assertEqual([r["device_id"] for r in results], [10, 11])
+        self.assertTrue(all(r["dispatched"] for r in results))
+        self.assertEqual(self.slept, [5.0, 5.0])  # held once per dispatched device
+        self.assertEqual([c["id"] for c in t.runmethod_calls], [10, 11])
+
+    def test_failed_dispatch_skips_hold_and_continues(self):
+        t = FakeTransport({10: full_json(10, "A"), 11: full_json(11, "B")}, fail_ids={10})
+        plan = m.build_plan([10, 11], "on", [], 5.0)
+        results = m.run_sequence("http://h:8080", plan, t, self._sleeper, self._announce)
+        self.assertFalse(results[0]["dispatched"])
+        self.assertIn("error", results[0])
+        self.assertTrue(results[1]["dispatched"])
+        self.assertEqual(self.slept, [5.0])  # only the successful device was held
+
+    def test_unreachable_device_does_not_abort(self):
+        t = FakeTransport({10: full_json(10, "A")})  # 11 missing -> 404
+        plan = m.build_plan([10, 11], "on", [], 1.0)
+        results = m.run_sequence("http://h:8080", plan, t, self._sleeper, self._announce)
+        self.assertTrue(results[0]["dispatched"])
+        self.assertFalse(results[1]["dispatched"])
+        self.assertIn("error", results[1])
+
+    def test_off_command_runs_after_hold(self):
+        t = FakeTransport({10: full_json(10, "A")})
+        plan = m.build_plan([10], "on", [], 2.0, off_command="off")
+        results = m.run_sequence("http://h:8080", plan, t, self._sleeper, self._announce)
+        self.assertTrue(results[0]["off_dispatched"])
+        # on then off for device 10
+        self.assertEqual([(c["id"], c["method"]) for c in t.runmethod_calls],
+                         [(10, "on"), (10, "off")])
+
+    def test_unknown_command_captured_per_device(self):
+        t = FakeTransport({10: full_json(10, "A", commands=[
+            {"name": "refresh", "parameters": [], "relatedAttribute": None, "capability": True}])})
+        plan = m.build_plan([10], "on", [], 1.0)
+        results = m.run_sequence("http://h:8080", plan, t, self._sleeper, self._announce)
+        self.assertFalse(results[0]["dispatched"])
+        self.assertIn("no command", results[0]["error"])
+
+
+class TestMain(unittest.TestCase):
+    def test_devices_flow_and_exit_zero(self):
+        t = FakeTransport({10: full_json(10, "A"), 11: full_json(11, "B")})
+        import contextlib
+        import io
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf), contextlib.redirect_stderr(io.StringIO()):
+            rc = m.main(["--ip", "192.0.2.11", "--devices", "10,11", "--duration", "3"],
+                        transport=t, sleeper=lambda _s: None)
+        self.assertEqual(rc, 0)
+        out = json.loads(buf.getvalue())
+        self.assertEqual(out["summary"], {"total": 2, "dispatched": 2, "failed": 0})
+
+    def test_any_failure_exits_one(self):
+        t = FakeTransport({10: full_json(10, "A"), 11: full_json(11, "B")}, fail_ids={11})
+        import contextlib
+        import io
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf), contextlib.redirect_stderr(io.StringIO()):
+            rc = m.main(["--ip", "192.0.2.11", "--devices", "10,11"],
+                        transport=t, sleeper=lambda _s: None)
+        self.assertEqual(rc, 1)
+        self.assertEqual(json.loads(buf.getvalue())["summary"]["failed"], 1)
+
+    def test_bad_device_id_exits_two(self):
+        import contextlib
+        import io
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            rc = m.main(["--ip", "192.0.2.11", "--devices", "10,bad"],
+                        transport=None, sleeper=lambda _s: None)
+        self.assertEqual(rc, 2)
+        self.assertIn("not an integer", err.getvalue())
+
+    def test_names_resolved_in_order(self):
+        devices_list = {"devices": [{"data": {"id": 10, "name": "A"}}, {"data": {"id": 11, "name": "B"}}]}
+
+        class NamesTransport(FakeTransport):
+            def __call__(self, method, url, body, content_type=None):
+                if method == "GET" and url.endswith("/hub2/devicesList"):
+                    return 200, {}, json.dumps(devices_list)
+                return super().__call__(method, url, body, content_type)
+
+        t = NamesTransport({10: full_json(10, "A"), 11: full_json(11, "B")})
+        import contextlib
+        import io
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf), contextlib.redirect_stderr(io.StringIO()):
+            rc = m.main(["--ip", "192.0.2.11", "--names", "A,B"], transport=t, sleeper=lambda _s: None)
+        self.assertEqual(rc, 0)
+        self.assertEqual([s["device_id"] for s in json.loads(buf.getvalue())["steps"]], [10, 11])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/_scripts/tests/test_hub_device_sequence.py
+++ b/skills/_scripts/tests/test_hub_device_sequence.py
@@ -29,9 +29,10 @@ def full_json(device_id=1639, name="Zone 8 Soil", commands=None):
 class FakeTransport:
     """Serves GET /device/fullJson/<id> and POST /device/runmethod. runmethod success is keyed by
     device id via `fail_ids`."""
-    def __init__(self, devices, fail_ids=()):
+    def __init__(self, devices, fail_ids=(), fail_methods=()):
         self.devices = devices  # {id: full_json}
         self.fail_ids = set(fail_ids)
+        self.fail_methods = set(fail_methods)  # command names that return success:false
         self.runmethod_calls = []
 
     def __call__(self, method, url, body, _content_type=None):
@@ -43,7 +44,7 @@ class FakeTransport:
         if method == "POST" and url.endswith("/device/runmethod"):
             payload = json.loads(body)
             self.runmethod_calls.append(payload)
-            ok = payload["id"] not in self.fail_ids
+            ok = payload["id"] not in self.fail_ids and payload["method"] not in self.fail_methods
             return 200, {}, json.dumps({"success": ok, "message": None if ok else "threw"})
         raise AssertionError(f"unexpected call {method} {url}")
 
@@ -122,6 +123,15 @@ class TestRunSequence(unittest.TestCase):
         self.assertEqual([(c["id"], c["method"]) for c in t.runmethod_calls],
                          [(10, "on"), (10, "off")])
 
+    def test_off_command_failure_recorded_and_counted(self):
+        t = FakeTransport({10: full_json(10, "A")}, fail_methods={"off"})
+        plan = m.build_plan([10], "on", [], 1.0, off_command="off")
+        results = m.run_sequence("http://h:8080", plan, t, self._sleeper, self._announce)
+        self.assertTrue(results[0]["dispatched"])          # on succeeded
+        self.assertFalse(results[0]["off_dispatched"])     # off returned success:false
+        self.assertIn("off_error", results[0])
+        self.assertEqual(m.summarize(results)["failed"], 1)
+
     def test_unknown_command_captured_per_device(self):
         t = FakeTransport({10: full_json(10, "A", commands=[
             {"name": "refresh", "parameters": [], "relatedAttribute": None, "capability": True}])})
@@ -164,6 +174,16 @@ class TestMain(unittest.TestCase):
                         transport=None, sleeper=lambda _s: None)
         self.assertEqual(rc, 2)
         self.assertIn("not an integer", err.getvalue())
+
+    def test_negative_duration_exits_two(self):
+        import contextlib
+        import io
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            rc = m.main(["--ip", "192.0.2.11", "--devices", "10", "--duration", "-5"],
+                        transport=None, sleeper=lambda _s: None)
+        self.assertEqual(rc, 2)
+        self.assertIn("must be >= 0", err.getvalue())
 
     def test_names_resolved_in_order(self):
         devices_list = {"devices": [{"data": {"id": 10, "name": "A"}}, {"data": {"id": 11, "name": "B"}}]}

--- a/skills/device-command/SKILL.md
+++ b/skills/device-command/SKILL.md
@@ -42,4 +42,4 @@ Read the output object, not the exit code alone:
 - `verification.changed: false` — unchanged, and **not** a failure. Commanding a device to the state it is already in produces no event (the change filter, `rules/state-vs-attributes.md`). Re-run against a different target state, or confirm the command was issued via `GET /device/eventsJson/<id>` with `Skill(skill: "debug")`.
 - `verification.changed: null` — the command declares no `relatedAttribute`, or the attribute is absent from the surface. Confirm through the event log rather than the command response.
 
-Report what was commanded, whether it dispatched, and whether the attribute moved. Finish here.
+Report what was commanded, whether it dispatched, and whether the attribute moved. To fire an ordered list of devices with a timed hold on each — mapping which physical thing each controls — use `Skill(skill: "device-sequence")`. Finish here.

--- a/skills/device-sequence/SKILL.md
+++ b/skills/device-sequence/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: device-sequence
+description: Fire an ordered list of Hubitat devices with a timed hold on each, so you can walk the property and bind each observation to a device id — which lamp is `Kitchen 3`, which shade is `Office Left`, which valve is irrigation zone 7. Use when the user wants to map which physical thing a device controls, identify which zone/lamp/shade/valve is which, run a set of devices one at a time in sequence, or fire devices on a timer for field verification.
+---
+
+# Device-Sequence Skill
+
+Process steps in order. Do not skip ahead.
+
+Answers "which physical thing does this device control?" by activating devices in a known order with a hold on each, so the person in the field binds every photo or observation to a device id instead of guessing. It builds on `device-command` — each command is validated against that device's real surface and dispatched over `/device/runmethod` — and adds the ordered walk, the timed hold, and live per-step narration.
+
+**A command is dispatched, not proven executed** (`rules/state-vs-attributes.md`). The confirmation here is the operator watching the physical device during its hold — that is the whole point of the timed walk, not a return code.
+
+## Step 1 — Frame the walk
+
+Establish the hub (`--ip <addr>` or `--hub <name>`), the **ordered** device list (`--devices 1639,1640,1641` by id, or `--names "Zone 1,Zone 2"` by exact display name), the command to run on each (`--command`, default `on`), the per-device hold (`--duration` seconds), and an optional `--off-command` (e.g. `off`) run on each device after its hold before the next. Set the hold long enough for the person to reach and observe each device. Proceed to Step 2.
+
+## Step 2 — Confirm the physical run
+
+This **physically activates** each device in turn — valves open, lights turn on, shades move. Confirm with the user which devices will fire, in what order, and that they are positioned to observe and record as the walk runs. For irrigation or anything with a real-world cost, confirm the command and duration before starting. Proceed to Step 3.
+
+## Step 3 — Run the sequence
+
+```
+python3 .tessl/plugins/jbaruch/hubitat-dev/skills/_scripts/hub_device_sequence.py --ip <addr> --devices <id,id,...> --command <name> --duration <seconds> [--off-command <name>]
+```
+
+Argument contract, exit codes, and output shape: `skills/_scripts/hub_device_sequence.py` module docstring. Live per-step narration (`[i/N] <device>: <command>`, then the hold) goes to stderr as the walk runs; the JSON summary lands on stdout at the end. A device that fails to dispatch is skipped without a hold and the walk continues. Proceed to Step 4.
+
+## Step 4 — Bind observations to device ids
+
+Read the `steps[]` log: each entry carries the `device_id`, `device_name`, and whether the command `dispatched`. Bind each photo or field note to the `device_id`/`device_name` of the step that was firing when it was taken — that mapping is the deliverable. Re-run any `dispatched:false` step individually with `Skill(skill: "device-command")` to see the command's own error and verification. Finish here.


### PR DESCRIPTION
**PR 5 of 6 for #78** — the second new skill, built on `device-command` (PR4).

Answers "which physical thing does this device control?" — fire an ordered device list with a timed hold on each, so a field walk binds every photo or observation to a device id (which lamp is `Kitchen 3`, which valve is irrigation zone 7).

## `skills/_scripts/hub_device_sequence.py` (+ 14 tests)
- Reuses the `device-command` primitives: each command is validated against that device's real surface and args coerced, then dispatched over `/device/runmethod`.
- Adds the ordered walk, a per-device `--duration` hold (so the operator can reach and observe), **live per-step narration to stderr**, and an optional `--off-command` run after each hold.
- A device that fails to dispatch is **skipped without a hold** — the walk continues rather than aborting.
- Confirmation is the operator observing during the hold, not a return code (`rules/state-vs-attributes.md`).
- `--devices 1,2,3` by id or `--names "A,B"` by exact display name.

## `skills/device-sequence/SKILL.md`
Sequential workflow: frame the walk → confirm the physical run → run → bind observations to device ids. `device-command` Step 4 now cross-references it.

## Verification
- `pyright` 0 errors; **295 unit tests pass** (14 new — injected transport, no-op sleeper, capturing narrator; no live hub or real clock); `tessl plugin lint` ✔.
- `tessl review run` remains credit-blocked (403); CI `skill-review` skips under the documented `credit-outage: skip` carve-out (flagged, self-heals on credit reset). Every other check gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)