### PR TITLE
feat(sensor-onboarding): verified fleet-install runbook skill (#78, closes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Added
+
+- **New skill `sensor-onboarding` — fleet install with a verified step per device** (`skills/sensor-onboarding/SKILL.md`, `README.md`, closes #78). The last piece of #78, from onboarding nine soil probes: a guide skill that walks each sensor through pair → confirm the built-in driver auto-selected (not the generic `Device`/`Device` unfinished-join signature) → name by function-and-position → raise event retention (`maxEvents` defaults to 11 changes/attribute — the step that decides whether the data survives) → read the **real** adjustable preferences from `fullJson.settings` rather than the datasheet (a sensor advertising a 1–240-minute interval may expose only `logEnable`/`txtEnable`) → mirror to a consuming hub and confirm the mirror formed → add to inactivity monitoring keyed on `lastActivityTime`/battery never a value's presence → acceptance-test past the settling window (a fresh soil probe's first hours read garbage — 6, 5, 4% climbing to 53 by evening is soil equilibrating, not a fault) → reconcile the post-pairing inventory against a pre-flight `/hub2/devicesList` snapshot so a stray or duplicate join surfaces. Encodes the two runbook steps that did not survive contact (the reporting interval was not adjustable; retention was missing). Cross-references `device-command` (acceptance test), `mesh-health` (mirror), and the `data-collection` / `driver-lifecycle` / `state-vs-attributes` rules; the rename/retention `/device/update` mutations carry the full-field-set and destructive mesh-boolean cautions from the endpoint reference. Skill auto-included via the `skills/` glob.
+
 ## 0.1.51 — 2026-07-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ All rules are always-on — installing the plugin means you want this context.
 | [device-sequence](skills/device-sequence/SKILL.md) | Firing an ordered list of devices with a timed hold on each — walk the property and bind each photo or observation to a device id (which lamp/shade/valve/zone is which). |
 | [device-removal](skills/device-removal/SKILL.md) | Safely removing a device — enumerate usage, warn on blast radius, verify after, and restore references onto a replacement. |
 | [device-migration](skills/device-migration/SKILL.md) | Moving every app reference from an old device to a new one — Swap Device, a virtual bridge/parking slot, a Hub Mesh re-home across hubs, or a guided manual re-select, chosen by why the swap is blocked. |
+| [sensor-onboarding](skills/sensor-onboarding/SKILL.md) | Onboarding sensors (or a fleet) with a verified step per device — pair, confirm the driver, name by function+position, raise retention, read the real preferences, mirror to a peer hub, add to inactivity monitoring, acceptance-test past the settling window, and reconcile the inventory. |
 
 Typical loop: `scaffold` → `lint-review` → `deploy` → `debug`, with `hub-config` set up once and `test` for anything with real logic. `mesh-health` is orthogonal — reach for it when the problem is the radio network (a flaky device, a ghost node) rather than the code.
 

--- a/skills/sensor-onboarding/SKILL.md
+++ b/skills/sensor-onboarding/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: sensor-onboarding
+description: Onboard one or more Hubitat sensors with verification at each step — pair, confirm the built-in driver auto-selected, name by function and position, raise event retention, read the real adjustable preferences, share to the mesh and confirm the mirror, add to inactivity monitoring, acceptance-test, and reconcile the inventory. Use when the user wants to onboard, install, add, or set up sensors (soil probes, contact/motion/temperature/energy sensors) on a hub, or roll out a sensor fleet.
+---
+
+# Sensor-Onboarding Skill
+
+Process steps in order. Do not skip ahead.
+
+A fleet install fails quietly one sensor at a time — a generic-driver join, a name that can't be told from its neighbor, default retention that drops the data a day later, a mesh mirror that never formed. Each step below verifies before moving on. A hand-written runbook for this had two steps that did not survive contact (the reporting interval was not adjustable, and retention was missing entirely); this skill encodes what actually held.
+
+## Step 1 — Snapshot the inventory before pairing
+
+Capture `GET /hub2/devicesList` (`skills/_reference/endpoints.md`) before any pairing. A join can mint a stray or duplicate device, and only a pre/post diff (Step 10) makes that visible. Save the id set. Proceed to Step 2.
+
+## Step 2 — Pair the sensor
+
+Pairing is physical — the user puts the radio into inclusion and pairs each device; the agent guides and waits. For a batch, pair one at a time so each new id is attributable. Proceed to Step 3.
+
+## Step 3 — Confirm the driver auto-selected
+
+Read `GET /device/fullJson/<id>` and confirm the device landed on a real built-in driver, not the generic `Device` / `Device` unfinished-join signature (`rules/zwave-zigbee-mesh.md`). A generic driver is an incomplete join — re-pair before continuing. Proceed to Step 4.
+
+## Step 4 — Name by function and position
+
+Name the device by **function and position** (`<function> - <position>`), qualifying even a single-sensor unit so a second sensor later does not force a rename (`rules/data-collection.md`). The rename is a `POST /device/update` mutation carrying the full field set, a `version` token, and a **destructive mesh-boolean trap** (`skills/_reference/endpoints.md`) — do it on the device edit page (`skills/_reference/playwright-ui.md`), or over HTTP only by reading the current full field set first and preserving every field. Proceed to Step 5.
+
+## Step 5 — Raise event retention
+
+This is the step that decides whether the collected data still exists tomorrow. `maxEvents` defaults to **11 changes per attribute** (`rules/data-collection.md`); raise it via `POST /device/update` before relying on the hub as a buffer (same full-field-set/mesh-boolean cautions as Step 4). Proceed to Step 6.
+
+## Step 6 — Read the real adjustable preferences
+
+Read `settings` from `fullJson`, never the datasheet — a built-in driver is frequently narrower than the hardware (`rules/driver-lifecycle.md`). A sensor advertising a 1–240-minute reporting interval may expose only `logEnable` / `txtEnable`, with no interval control. Report what is actually adjustable rather than assuming a configurable exists. Proceed to Step 7.
+
+## Step 7 — Mirror the device to the consuming hub
+
+If the device serves another hub, share it — `GET /device/addToMesh/<id>` on the source, then link it on the destination (`GET /device/createLinked/...`); sharing is two-sided and a shared device does not auto-appear (`skills/_reference/endpoints.md`). Confirm the mirror exists on the consuming hub before trusting it — `Skill(skill: "mesh-health")` verifies peer/mirror state. Skip this step for a single-hub sensor. Proceed to Step 8.
+
+## Step 8 — Add to inactivity monitoring
+
+Add the sensor to the inactivity monitor keyed on `lastActivityTime` or battery, **never on a value's presence in the event log** — a slow-moving sensor is change-filtered and a gap means steady, not silent (`rules/state-vs-attributes.md`, `rules/data-collection.md`). Proceed to Step 9.
+
+## Step 9 — Acceptance-test the sensor
+
+Exercise the sensor and confirm it responds — `Skill(skill: "device-command")` runs a command (or `refresh`) and verifies by observation. **Exclude the settling window:** a freshly installed soil probe's first hours are garbage — readings of 6, 5, 4 percent climbing to 53 by evening are disturbed soil equilibrating, not a fault, and the vendor documents settling as several wet/dry cycles. Do not baseline or health-check inside that window. Proceed to Step 10.
+
+## Step 10 — Reconcile the fleet
+
+Re-read `GET /hub2/devicesList` and diff against the Step 1 snapshot. Every new id must be a device you paired; a stray or duplicate join surfaces only here. Report the reconciled inventory and any sensor still short of a step. Finish here.

--- a/skills/sensor-onboarding/SKILL.md
+++ b/skills/sensor-onboarding/SKILL.md
@@ -7,7 +7,7 @@ description: Onboard one or more Hubitat sensors with verification at each step 
 
 Process steps in order. Do not skip ahead.
 
-A fleet install fails quietly one sensor at a time — a generic-driver join, a name that can't be told from its neighbor, default retention that drops the data a day later, a mesh mirror that never formed. Each step below verifies before moving on. A hand-written runbook for this had two steps that did not survive contact (the reporting interval was not adjustable, and retention was missing entirely); this skill encodes what actually held.
+A fleet install fails quietly one sensor at a time — a generic-driver join, a name that can't be told from its neighbor, default retention that drops the data a day later, a mesh mirror that never formed. Each step below verifies before moving on.
 
 ## Step 1 — Snapshot the inventory before pairing
 
@@ -43,7 +43,7 @@ Add the sensor to the inactivity monitor keyed on `lastActivityTime` or battery,
 
 ## Step 9 — Acceptance-test the sensor
 
-Exercise the sensor and confirm it responds — `Skill(skill: "device-command")` runs a command (or `refresh`) and verifies by observation. **Exclude the settling window:** a freshly installed soil probe's first hours are garbage — readings of 6, 5, 4 percent climbing to 53 by evening are disturbed soil equilibrating, not a fault, and the vendor documents settling as several wet/dry cycles. Do not baseline or health-check inside that window. Proceed to Step 10.
+Exercise the sensor and confirm it responds — `Skill(skill: "device-command")` runs a command (or `refresh`) and verifies by observation. **Exclude the settling window:** a freshly installed sensor's first hours can read garbage while it physically equilibrates, not because it is faulty (a soil probe settles over several wet/dry cycles). Do not baseline or health-check inside that window. Proceed to Step 10.
 
 ## Step 10 — Reconcile the fleet
 

--- a/skills/sensor-onboarding/SKILL.md
+++ b/skills/sensor-onboarding/SKILL.md
@@ -5,9 +5,7 @@ description: Onboard one or more Hubitat sensors with verification at each step 
 
 # Sensor-Onboarding Skill
 
-Process steps in order. Do not skip ahead.
-
-A fleet install fails quietly one sensor at a time — a generic-driver join, a name that can't be told from its neighbor, default retention that drops the data a day later, a mesh mirror that never formed. Each step below verifies before moving on.
+Process steps in order. Do not skip ahead. Each step verifies before the next.
 
 ## Step 1 — Snapshot the inventory before pairing
 
@@ -43,7 +41,7 @@ Add the sensor to the inactivity monitor keyed on `lastActivityTime` or battery,
 
 ## Step 9 — Acceptance-test the sensor
 
-Exercise the sensor and confirm it responds — `Skill(skill: "device-command")` runs a command (or `refresh`) and verifies by observation. **Exclude the settling window:** a freshly installed sensor's first hours can read garbage while it physically equilibrates, not because it is faulty (a soil probe settles over several wet/dry cycles). Do not baseline or health-check inside that window. Proceed to Step 10.
+Exercise the sensor and confirm it responds — `Skill(skill: "device-command")` runs a command (or `refresh`) and verifies by observation. **Exclude the settling window:** a freshly installed sensor's first hours can read garbage while it physically equilibrates (a soil probe settles over several wet/dry cycles). Do not baseline or health-check inside that window. Proceed to Step 10.
 
 ## Step 10 — Reconcile the fleet
 


### PR DESCRIPTION
**PR 6 of 6 for #78 — closes the issue.** The last piece: a guide skill turning the hand-written fleet runbook into verified, ordered steps (from onboarding nine soil probes).

## `skills/sensor-onboarding/SKILL.md` (sequential workflow, 10 steps)
1. **Snapshot the inventory** (`/hub2/devicesList`) before pairing — so a stray/duplicate join surfaces at Step 10.
2. **Pair** (physical, user-driven, one at a time).
3. **Confirm the driver auto-selected** — reject the generic `Device`/`Device` unfinished-join.
4. **Name by function and position** (`rules/data-collection.md`).
5. **Raise event retention** — `maxEvents` defaults to 11 changes/attr; the step that decides whether data survives.
6. **Read the real adjustable preferences** from `fullJson.settings`, not the datasheet (the reporting-interval lesson).
7. **Mirror to a consuming hub** and confirm the mirror formed (`Skill(mesh-health)`).
8. **Add to inactivity monitoring** keyed on `lastActivityTime`/battery, never a value's presence.
9. **Acceptance-test** (`Skill(device-command)`) past the **settling window** (a fresh soil probe's first hours read garbage — equilibrating, not a fault).
10. **Reconcile** the inventory against the Step 1 snapshot.

Encodes the two runbook steps that did not survive contact (interval not adjustable; retention missing). The rename/retention `/device/update` mutations carry the full-field-set + destructive mesh-boolean cautions from the endpoint reference.

## Verification
- `tessl plugin lint` ✔; step titles flat and single-action; typed `Skill()` calls; no scripts (guide skill), so the 297-test suite is unaffected.
- `tessl review run` remains credit-blocked; CI `skill-review` skips under the documented `credit-outage: skip` carve-out.

## #78 wrap-up (6 PRs)
1. #80 endpoints + 5 rule edits · 2. #81 `self-reported-vs-measured` rule · 3. #82 `data-collection` rule · 4. #83 `device-command` skill · 5. #84 `device-sequence` skill · 6. this — `sensor-onboarding` skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)