### PR TITLE
fix(deploy): report a compile error as a save rejection, not a version conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Fixed
+
+- **`hub_deploy.py` reported a Groovy compile error as a stale-version conflict** (`skills/_scripts/hubclient.py`, tests). The hub rejects an uncompilable save with `{"status":"error","version":N,"errorMessage":<compiler diagnostics>}`, and the echoed `version` field tripped the `"version" in text.lower()` heuristic, so a typo surfaced as "the hub has a newer version — re-pull and reconcile." That advice points outward at a phantom concurrent editor when the fault is inside your own source, and `rules/multi-hub-topology.md` tells the reader to trust it. `deploy()` now parses the response and, on a non-success JSON body carrying `errorMessage`, surfaces that message verbatim as a save rejection (exit 1, distinct from the conflict exit 2) before the version heuristic runs. The heuristic stays only for a non-JSON HTML rejection page — the genuine stale-version JSON shape is still unconfirmed, so nothing was invented for it. Closes #93.
+
 ## 0.1.59 — 2026-08-11
 
 ### Added

--- a/skills/_scripts/hub_deploy.py
+++ b/skills/_scripts/hub_deploy.py
@@ -11,6 +11,10 @@ Usage:
     hub_deploy.py --kind app --source a.groovy --id 143 --ip 192.0.2.10
     hub_deploy.py --kind driver --source d.groovy --name "My Driver" --ip 192.0.2.10
 
+A save rejection — most often a Groovy compile error — surfaces the hub's errorMessage
+verbatim and exits 1, distinct from the version-conflict path so its "re-pull and reconcile"
+advice never fires on a typo in your own source.
+
 Exit: 0 on success, 2 on a version conflict (re-pull and reconcile), 1 on other errors.
 """
 import argparse

--- a/skills/_scripts/hubclient.py
+++ b/skills/_scripts/hubclient.py
@@ -210,30 +210,27 @@ class HubClient:
         try:
             payload = json.loads(text)
         except json.JSONDecodeError:
-            payload = None
+            # Non-JSON response (an HTML page). This is the ONLY case the version heuristic runs
+            # in — the legacy tell for a stale-version rejection is the word "version" in the page.
+            # A parsed JSON body's echoed "version" field never reaches here, so a compile error
+            # (status "error" with the field) can no longer be misread as an optimistic-concurrency
+            # conflict. The genuine-conflict JSON shape is unconfirmed, so nothing is invented for it.
+            if "version" in text.lower():
+                raise DeployConflict(
+                    f"hub rejected the update for {kind} id={plan['id']} — the hub has a newer "
+                    f"version than {plan['version']}. Re-pull and reconcile before deploying.")
+            raise HubError(
+                f"update {kind} id={plan['id']} did not confirm success (HTTP {status}): {text[:200]}")
+        # Parsed JSON. A save returns {"status":"success"}; a rejection carries the reason in
+        # errorMessage. Surface that message verbatim — a Groovy compile error and a stale-version
+        # rejection both come back as status "error", and errorMessage is the only thing that tells
+        # them apart. A JSON body without an errorMessage (or a non-object JSON value) is reported
+        # plainly rather than guessed at — never as a conflict off the echoed "version" field.
         if isinstance(payload, dict):
             if payload.get("status") == "success":
                 return {"action": "update", "id": plan["id"], "version": plan["version"]}
-            # A rejection arrives as {"status":"error", "errorMessage": <the hub's reason>}.
-            # Surface that message verbatim: a Groovy compile error and a stale-version
-            # rejection both come back as status "error", and errorMessage is the only thing
-            # that tells them apart. This must run before the version heuristic below — the
-            # echoed "version" field is present in every rejection, so keying a conflict off
-            # the word "version" misreads a compile error as optimistic-concurrency failure.
             message = payload.get("errorMessage")
             if message:
                 raise HubError(f"hub rejected the save for {kind} id={plan['id']}: {message}")
-            # A JSON error with no errorMessage: the reason is unknown, and the echoed "version"
-            # field is not evidence of a conflict. Report it plainly rather than guessing — the
-            # version heuristic below is only for a non-JSON HTML page, never a parsed body.
-            raise HubError(
-                f"update {kind} id={plan['id']} did not confirm success (HTTP {status}): {text[:200]}")
-        # Non-JSON response (payload is None): the legacy tell for a stale-version rejection is the
-        # word "version" in an HTML rejection page. The genuine-conflict JSON shape is unconfirmed,
-        # so this heuristic is scoped to the unparseable case, never a JSON body's echoed field.
-        if "version" in text.lower():
-            raise DeployConflict(
-                f"hub rejected the update for {kind} id={plan['id']} — the hub has a newer "
-                f"version than {plan['version']}. Re-pull and reconcile before deploying.")
         raise HubError(
             f"update {kind} id={plan['id']} did not confirm success (HTTP {status}): {text[:200]}")

--- a/skills/_scripts/hubclient.py
+++ b/skills/_scripts/hubclient.py
@@ -206,13 +206,26 @@ class HubClient:
             _PATHS[kind]["update"], {"id": plan["id"], "version": plan["version"], "source": source})
         # Confirm via the parsed JSON status field, exactly "success" — a substring match
         # would wrongly accept {"status":"unsuccessful"} or an HTML page mentioning "success".
-        # The hub's /ajax/update returns {"status":"success"}.
+        # The hub's /ajax/update returns {"status":"success"} on save.
         try:
-            confirmed = json.loads(text).get("status") == "success"
-        except (json.JSONDecodeError, AttributeError):
-            confirmed = False
-        if confirmed:
-            return {"action": "update", "id": plan["id"], "version": plan["version"]}
+            payload = json.loads(text)
+        except json.JSONDecodeError:
+            payload = None
+        if isinstance(payload, dict):
+            if payload.get("status") == "success":
+                return {"action": "update", "id": plan["id"], "version": plan["version"]}
+            # A rejection arrives as {"status":"error", "errorMessage": <the hub's reason>}.
+            # Surface that message verbatim: a Groovy compile error and a stale-version
+            # rejection both come back as status "error", and errorMessage is the only thing
+            # that tells them apart. This must run before the version heuristic below — the
+            # echoed "version" field is present in every rejection, so keying a conflict off
+            # the word "version" misreads a compile error as optimistic-concurrency failure.
+            message = payload.get("errorMessage")
+            if message:
+                raise HubError(f"hub rejected the save for {kind} id={plan['id']}: {message}")
+        # No parseable errorMessage. The legacy tell for a stale-version rejection is the word
+        # "version" in a non-JSON HTML rejection page; the genuine-conflict JSON shape is
+        # unconfirmed, so this stays a heuristic on the raw text rather than a parsed field.
         if "version" in text.lower():
             raise DeployConflict(
                 f"hub rejected the update for {kind} id={plan['id']} — the hub has a newer "

--- a/skills/_scripts/hubclient.py
+++ b/skills/_scripts/hubclient.py
@@ -223,9 +223,14 @@ class HubClient:
             message = payload.get("errorMessage")
             if message:
                 raise HubError(f"hub rejected the save for {kind} id={plan['id']}: {message}")
-        # No parseable errorMessage. The legacy tell for a stale-version rejection is the word
-        # "version" in a non-JSON HTML rejection page; the genuine-conflict JSON shape is
-        # unconfirmed, so this stays a heuristic on the raw text rather than a parsed field.
+            # A JSON error with no errorMessage: the reason is unknown, and the echoed "version"
+            # field is not evidence of a conflict. Report it plainly rather than guessing — the
+            # version heuristic below is only for a non-JSON HTML page, never a parsed body.
+            raise HubError(
+                f"update {kind} id={plan['id']} did not confirm success (HTTP {status}): {text[:200]}")
+        # Non-JSON response (payload is None): the legacy tell for a stale-version rejection is the
+        # word "version" in an HTML rejection page. The genuine-conflict JSON shape is unconfirmed,
+        # so this heuristic is scoped to the unparseable case, never a JSON body's echoed field.
         if "version" in text.lower():
             raise DeployConflict(
                 f"hub rejected the update for {kind} id={plan['id']} — the hub has a newer "

--- a/skills/_scripts/tests/test_hubclient.py
+++ b/skills/_scripts/tests/test_hubclient.py
@@ -123,14 +123,28 @@ class TestDeploy(unittest.TestCase):
         post = [call for call in t.calls if call[0] == "POST"][0]
         self.assertIn("version=3", post[2])
 
-    def test_stale_version_raises_conflict(self):
+    def test_stale_version_raises_conflict_on_non_json_page(self):
+        # The version heuristic is scoped to a non-JSON HTML rejection page — a parsed body's
+        # echoed "version" field must never trip it (that was the compile-error misclassification).
         t = make_transport({
             ("GET", "/driver/ajax/code"): (200, {}, json.dumps({"id": 5, "version": 3, "source": "old"})),
-            ("POST", "/driver/ajax/update"): (200, {}, json.dumps({"error": "version mismatch"})),
+            ("POST", "/driver/ajax/update"): (200, {}, "<html>a newer version exists on the hub</html>"),
         })
         c = hubclient.HubClient("http://h:8080", t)
         with self.assertRaises(hubclient.DeployConflict):
             c.deploy("driver", "x", code_id=5)
+
+    def test_json_error_without_message_is_not_a_conflict(self):
+        # A JSON error body with no errorMessage but an echoed "version" field must NOT be read as
+        # a conflict — report it plainly (HubError, exit 1), never DeployConflict (exit 2).
+        t = make_transport({
+            ("GET", "/driver/ajax/code"): (200, {}, json.dumps({"id": 5, "version": 8, "source": "old"})),
+            ("POST", "/driver/ajax/update"): (200, {}, json.dumps({"id": 5, "version": 8, "status": "error"})),
+        })
+        c = hubclient.HubClient("http://h:8080", t)
+        with self.assertRaises(hubclient.HubError) as ctx:
+            c.deploy("driver", "x", code_id=5)
+        self.assertNotIsInstance(ctx.exception, hubclient.DeployConflict)
 
     def test_compile_error_reports_message_not_conflict(self):
         # A compile rejection echoes {"status":"error","version":N,"errorMessage":...}. The

--- a/skills/_scripts/tests/test_hubclient.py
+++ b/skills/_scripts/tests/test_hubclient.py
@@ -162,6 +162,18 @@ class TestDeploy(unittest.TestCase):
         self.assertNotIsInstance(ctx.exception, hubclient.DeployConflict)
         self.assertIn("Modifier 'static' not allowed here.", str(ctx.exception))
 
+    def test_non_object_json_with_version_is_not_a_conflict(self):
+        # A valid JSON string/array containing "version" parsed fine — it is not an HTML page,
+        # so the version heuristic (JSON-parse-failure only) must not apply. Report plainly.
+        t = make_transport({
+            ("GET", "/driver/ajax/code"): (200, {}, json.dumps({"id": 5, "version": 3, "source": "old"})),
+            ("POST", "/driver/ajax/update"): (200, {}, json.dumps("version mismatch")),
+        })
+        c = hubclient.HubClient("http://h:8080", t)
+        with self.assertRaises(hubclient.HubError) as ctx:
+            c.deploy("driver", "x", code_id=5)
+        self.assertNotIsInstance(ctx.exception, hubclient.DeployConflict)
+
     def test_create_without_new_id_raises(self):
         # A create that redirects somewhere without an editor id must not return {id: None}.
         t = make_transport({("POST", "/driver/save"): (302, {"Location": "/error"}, "")})

--- a/skills/_scripts/tests/test_hubclient.py
+++ b/skills/_scripts/tests/test_hubclient.py
@@ -132,6 +132,22 @@ class TestDeploy(unittest.TestCase):
         with self.assertRaises(hubclient.DeployConflict):
             c.deploy("driver", "x", code_id=5)
 
+    def test_compile_error_reports_message_not_conflict(self):
+        # A compile rejection echoes {"status":"error","version":N,"errorMessage":...}. The
+        # echoed "version" field must NOT make it read as a stale-version conflict — surface
+        # the hub's message verbatim and raise HubError (exit 1), not DeployConflict (exit 2).
+        t = make_transport({
+            ("GET", "/driver/ajax/code"): (200, {}, json.dumps({"id": 5, "version": 8, "source": "old"})),
+            ("POST", "/driver/ajax/update"): (200, {}, json.dumps(
+                {"id": 5, "version": 8, "status": "error",
+                 "errorMessage": "Modifier 'static' not allowed here.\n @ line 242, column 1."})),
+        })
+        c = hubclient.HubClient("http://h:8080", t)
+        with self.assertRaises(hubclient.HubError) as ctx:
+            c.deploy("driver", "x", code_id=5)
+        self.assertNotIsInstance(ctx.exception, hubclient.DeployConflict)
+        self.assertIn("Modifier 'static' not allowed here.", str(ctx.exception))
+
     def test_create_without_new_id_raises(self):
         # A create that redirects somewhere without an editor id must not return {id: None}.
         t = make_transport({("POST", "/driver/save"): (302, {"Location": "/error"}, "")})


### PR DESCRIPTION
## Summary
- The hub rejects an uncompilable Groovy save with `{"status":"error","version":N,"errorMessage":<compiler diagnostics>}`. The echoed `version` field tripped `hubclient.deploy()`'s `"version" in text.lower()` heuristic, so a compile error surfaced as a stale-version conflict — advice that sends the operator hunting for a phantom concurrent editor when the fault is a typo in their own source.
- `deploy()` now parses the response and, on a non-success JSON body carrying `errorMessage`, surfaces that message verbatim as a save rejection (exit 1, distinct from the conflict exit 2) before the version heuristic runs.
- The heuristic stays only for a non-JSON HTML rejection page — the genuine stale-version JSON shape is still unconfirmed (issue's open loose end), so nothing was invented for it.

Closes #93.

## Test plan
- [x] `python3 -m unittest tests.test_hubclient` — 27 pass, incl. new `test_compile_error_reports_message_not_conflict`
- [x] `pyright skills/_scripts/` — 0 errors