### PR TITLE
chore(prose): fold deferred context-writing-style advisories (#99, #102)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### Changed
+
+- **Folded two deferred `context-writing-style` advisories from the #91 and #101 reviews** (`rules/app-lifecycle.md`, `skills/debug/SKILL.md`). Presentation-only, no behavior change. Closes #99, #102.
+  - `rules/app-lifecycle.md` `menu`-vs-`category` bullet dropped its named worked example (moved here): `Vacation Lighting Director` ships as `category: "Safety & Security"` but `menu: "Apps"`, so setting only `category` still leaves the app filed under `Apps` — the rule keeps the general directive alone.
+  - `rules/app-lifecycle.md` `menu`-lint bullet dropped its grounding-and-uncertainty prose (moved here): the three observed `menu` values (`Apps`, `Automations`, `Integrations`) are grounded on one hub / one platform version (C-8 Pro, 2.5.1.135), and whether that set is fixed across versions or what an invalid string does is unverified — which is why `lint-review` warns only on an absent `menu`, never on an unrecognized value. The rule now states that contract directly.
+  - `skills/debug/SKILL.md` Step 1 dropped the em-dash-appended justification clause "— no log tail will show it" from the network-path-failure directive, keeping the instruction to rule out the network path before tailing logs.
+
 ## 0.1.59 — 2026-08-11
 
 ### Added

--- a/rules/app-lifecycle.md
+++ b/rules/app-lifecycle.md
@@ -15,12 +15,12 @@ An app is not a long-running process. The hub wakes it on an event, a schedule, 
   - Omitting it defaults to `Apps`, misfiling an event/presence-driven automation.
   - Measured values (C-8 Pro, 2.5.1.135): `Apps`, `Automations`, `Integrations`.
   - Placement: third-party network integration → `Integrations`; device / time / presence automation → `Automations`; utility, manager, or dashboard → `Apps`.
-- **`menu` is not `category`** — neither implies the other. `Vacation Lighting Director` is `category: "Safety & Security"` but `menu: "Apps"`. Setting only `category` still leaves the app in `Apps`.
+- **`menu` is not `category`** — neither implies the other. Setting only `category` still leaves the app in `Apps`.
 - **`category`** — separate metadata: `Convenience`, `Safety & Security`, `Utility`, `My Apps`, `Hidden`.
 - **`singleInstance: true`** — the app installs once, not repeatedly (the usual parent-app case).
 - **`installOnOpen: true`** — the instance is created when its page opens, not on the first Done.
 - **`parent`** — declares this a child app under a named parent (`namespace:name`), set on the child.
-- The three observed `menu` values are grounded on one hub/one platform version. Whether the set is fixed across versions, or what an invalid string does, is unverified, so `lint-review` warns only on an **absent** `menu`, never on an unrecognized value.
+- `lint-review` warns only on an **absent** `menu`, never on an unrecognized value.
 
 ## Callbacks
 

--- a/skills/debug/SKILL.md
+++ b/skills/debug/SKILL.md
@@ -13,7 +13,7 @@ Hubitat has no debugger — diagnosis is `log.debug` plus the live stream (`logg
 
 Read `skills/_reference/endpoints.md` before probing for any endpoint.
 
-First, check the failure domain. A HomeKit integration that stopped working, or a bridge that never appears in Apple Home, after a network or VLAN change is a **network-path failure**, not a hub-code failure — no log tail will show it. Cross a segmented network (hub on an isolated VLAN, controllers on another) and mDNS discovery plus the HAP TCP session each need their own firewall exception: `skills/_reference/homekit-mdns-network.md`. Rule that out before reaching for the log stream.
+First, check the failure domain. A HomeKit integration that stopped working, or a bridge that never appears in Apple Home, after a network or VLAN change is a **network-path failure**, not a hub-code failure. Cross a segmented network (hub on an isolated VLAN, controllers on another) and mDNS discovery plus the HAP TCP session each need their own firewall exception: `skills/_reference/homekit-mdns-network.md`. Rule that out before reaching for the log stream.
 
 Establish what is wrong and which app/driver it concerns, and pick the socket:
 - `logsocket` — the debug/info/warn/error log lines (default; use for "my code does X wrong").


### PR DESCRIPTION
## Summary
Presentation-only prose cleanups deferred as advisories from the #91 and #101 policy reviews. No behavior change.

- **`rules/app-lifecycle.md`** — drop the named worked example from the `menu`-vs-`category` bullet (#99) and the grounding/uncertainty prose from the `menu`-lint bullet, stating the lint contract directly. Both moved to CHANGELOG per `context-writing-style` What-to-Cut.
- **`skills/debug/SKILL.md`** — drop the em-dash-appended justification clause "— no log tail will show it" from the network-path-failure directive, keeping the instruction to rule out the network path first (#102).

Closes #99, #102.

## Test plan
- [x] Diff self-audited against `context-writing-style` — edits only remove prose; no banned connectives introduced in the rule/skill bodies
- [ ] Policy reviewer verdict (Codex fleet reviewer, not tessl-credit-gated)

> Note: CI `plugin` job is currently red org-wide on a tessl credits outage (skill-review step), unrelated to this diff — see #104.