### PR TITLE
chore(app-lifecycle): fold deferred context-writing-style advisory (#99)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Changed
+
+- **Folded a deferred `context-writing-style` advisory from the #91 review** (`rules/app-lifecycle.md`). Presentation-only, no behavior change. The `menu`-vs-`category` bullet dropped its named worked example (moved here): `Vacation Lighting Director` ships as `category: "Safety & Security"` but `menu: "Apps"`, so setting only `category` still files the app under `Apps`. The `menu`-lint bullet dropped its grounding-and-uncertainty prose (moved here): the three observed `menu` values (`Apps`, `Automations`, `Integrations`) are grounded on one hub / one platform version (C-8 Pro, 2.5.1.135), and whether that set is fixed across versions or what an invalid string does is unverified — which is why `lint-review` warns only on an absent `menu`, never on an unrecognized value. The rule now states each contract directly. Closes #99.
+
 ### Fixed
 
 - **`hub_deploy.py` reported a Groovy compile error as a stale-version conflict** (`skills/_scripts/hubclient.py`, tests). The hub rejects an uncompilable save with `{"status":"error","version":N,"errorMessage":<compiler diagnostics>}`, and the echoed `version` field tripped the `"version" in text.lower()` heuristic, so a typo surfaced as "the hub has a newer version — re-pull and reconcile." That advice points outward at a phantom concurrent editor when the fault is inside your own source, and `rules/multi-hub-topology.md` tells the reader to trust it. `deploy()` now parses the response and, on a non-success JSON body carrying `errorMessage`, surfaces that message verbatim as a save rejection (exit 1, distinct from the conflict exit 2) before the version heuristic runs. The heuristic stays only for a non-JSON HTML rejection page — the genuine stale-version JSON shape is still unconfirmed, so nothing was invented for it. Closes #93.

--- a/rules/app-lifecycle.md
+++ b/rules/app-lifecycle.md
@@ -15,12 +15,12 @@ An app is not a long-running process. The hub wakes it on an event, a schedule, 
   - Omitting it defaults to `Apps`, misfiling an event/presence-driven automation.
   - Measured values (C-8 Pro, 2.5.1.135): `Apps`, `Automations`, `Integrations`.
   - Placement: third-party network integration → `Integrations`; device / time / presence automation → `Automations`; utility, manager, or dashboard → `Apps`.
-- **`menu` is not `category`** — neither implies the other. `Vacation Lighting Director` is `category: "Safety & Security"` but `menu: "Apps"`. Setting only `category` still leaves the app in `Apps`.
+- **`menu` is not `category`** — neither implies the other. Setting only `category` still leaves the app in `Apps`.
 - **`category`** — separate metadata: `Convenience`, `Safety & Security`, `Utility`, `My Apps`, `Hidden`.
 - **`singleInstance: true`** — the app installs once, not repeatedly (the usual parent-app case).
 - **`installOnOpen: true`** — the instance is created when its page opens, not on the first Done.
 - **`parent`** — declares this a child app under a named parent (`namespace:name`), set on the child.
-- The three observed `menu` values are grounded on one hub/one platform version. Whether the set is fixed across versions, or what an invalid string does, is unverified, so `lint-review` warns only on an **absent** `menu`, never on an unrecognized value.
+- `lint-review` warns only on an **absent** `menu`, never on an unrecognized value.
 
 ## Callbacks
 


### PR DESCRIPTION
## Summary
Rule-only, presentation-only prose cleanup — the `context-writing-style` advisory deferred from the #91 review. Split out of #105 so it ships independently of that PR's `debug/SKILL.md` change (#102), which is currently blocked by the tessl skill-review credit outage.

- `rules/app-lifecycle.md` — drop the named worked example from the `menu`-vs-`category` bullet and the grounding/uncertainty prose from the `menu`-lint bullet, stating each contract directly. Detail moved to CHANGELOG.

Closes #99.

## Test plan
- [x] Diff self-audited against `context-writing-style` — removes prose, no banned connectives introduced
- [ ] Policy reviewer verdict