### PR TITLE
chore(debug): fold deferred context-writing-style advisory (#102)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Changed
 
+- **Folded a deferred `context-writing-style` advisory from the #101 review** (`skills/debug/SKILL.md`). Presentation-only, no behavior change. Step 1 dropped the em-dash-appended justification clause "— no log tail will show it" from the network-path-failure directive, keeping the instruction to rule out the network path before tailing logs. Closes #102.
 - **Folded a deferred `context-writing-style` advisory from the #91 review** (`rules/app-lifecycle.md`). Presentation-only, no behavior change. The `menu`-vs-`category` bullet dropped its named worked example (moved here): `Vacation Lighting Director` ships as `category: "Safety & Security"` but `menu: "Apps"`, so setting only `category` still files the app under `Apps`. The `menu`-lint bullet dropped its grounding-and-uncertainty prose (moved here): the three observed `menu` values (`Apps`, `Automations`, `Integrations`) are grounded on one hub / one platform version (C-8 Pro, 2.5.1.135), and whether that set is fixed across versions or what an invalid string does is unverified — which is why `lint-review` warns only on an absent `menu`, never on an unrecognized value. The rule now states each contract directly. Closes #99.
 
 ### Fixed

--- a/skills/debug/SKILL.md
+++ b/skills/debug/SKILL.md
@@ -13,7 +13,7 @@ Hubitat has no debugger — diagnosis is `log.debug` plus the live stream (`logg
 
 Read `skills/_reference/endpoints.md` before probing for any endpoint.
 
-First, check the failure domain. A HomeKit integration that stopped working, or a bridge that never appears in Apple Home, after a network or VLAN change is a **network-path failure**, not a hub-code failure — no log tail will show it. Cross a segmented network (hub on an isolated VLAN, controllers on another) and mDNS discovery plus the HAP TCP session each need their own firewall exception: `skills/_reference/homekit-mdns-network.md`. Rule that out before reaching for the log stream.
+First, check the failure domain. A HomeKit integration that stopped working, or a bridge that never appears in Apple Home, after a network or VLAN change is a **network-path failure**, not a hub-code failure. Cross a segmented network (hub on an isolated VLAN, controllers on another) and mDNS discovery plus the HAP TCP session each need their own firewall exception: `skills/_reference/homekit-mdns-network.md`. Rule that out before reaching for the log stream.
 
 Establish what is wrong and which app/driver it concerns, and pick the socket:
 - `logsocket` — the debug/info/warn/error log lines (default; use for "my code does X wrong").


### PR DESCRIPTION
## Summary
Split out of #105 (whose #99 half shipped in 0.1.64). Presentation-only, one-line prose cleanup.

- `skills/debug/SKILL.md` — Step 1 drops the em-dash-appended justification clause "— no log tail will show it" from the network-path-failure directive, keeping the instruction to rule out the network path before tailing logs.

Closes #102.

> **Blocked on the tessl credit outage:** this changes a `SKILL.md`, so the credit-gated "Skill review (changed only)" step fails in both CI and publish until the org's tessl credits are restored. Everything else is ready.