### PR TITLE
ci: bump the skill-review action pin past the credit-outage bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       # review failure still hard-fails. De-vendored now that the native input
       # exists (jbaruch/coding-policy#188 / #190).
       - name: Skill review (changed only)
-        uses: jbaruch/coding-policy/.github/actions/skill-review@3e3f74e90f1ff6ae283fedc51a7191d1b628b543
+        uses: jbaruch/coding-policy/.github/actions/skill-review@bbea1b92c621e1330278e04914500783e75bc78e
         with:
           threshold: '85'
           credit-outage: 'skip'


### PR DESCRIPTION
**This PR is a CI change and nothing else** — `rules/ci-safety.md` Hands Off CI Config, which treats an explicitly CI-scoped PR as the approval artifact rather than an unannounced edit. One line in `.github/workflows/ci.yml`.

## The failure

CI has been red on `main` since 2026-08-12, and it blocks every PR that touches a skill. The `plugin` job:

```
✘ Your organization has run out of credits. Upgrade your plan or buy more credits to continue.
##[error]Skill review failed for 'debug' (exit 1) — not a credits outage — blocking publish.
```

An out-of-credits outage, classified as not one.

## Why

The pinned revision's `is_credit_outage()` requires **both** the credit phrase **and** the literal string `403`:

```sh
printf '%s' "$1" | grep -qiF 'run out of credits' \
  && printf '%s' "$1" | grep -qF '403'
```

The tessl CLI prints the billing failure with no status code — confirmed on both the deprecated `tessl skill review` path (this repo's CI log) and `tessl review run` (reproduced locally while working on #113). The conjunct is unsatisfiable, so `credit-outage: skip` is dead code and the carve-out it exists to provide never fires.

## The fix

Already upstream. `jbaruch/coding-policy` main adds a second branch matching the CLI's billing sentence as a whole line, tolerating the leading `✘` glyph, and covers it with a `billing-sentence` unit-test fixture byte-identical to what this repo's run produced. This PR bumps the pin from `3e3f74e9` to `bbea1b92` to pick it up.

**Interface compatibility checked:** the only input added since the old pin is an optional `workspace` (default `''`). Every input the existing `with:` block passes — `threshold`, `credit-outage` — is unchanged, so no `with:` edit is needed.

## Expected result

The gate goes back to what the carve-out prescribes: the affected skills publish unreviewed with a `::warning::` and a run-summary note naming each one, and it self-heals when credits return. Every non-credit review failure still hard-fails.

Unblocks #113.