### PR TITLE
fix(device-lifecycle): a mesh rename propagates the mirror's name, not its label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Fixed
+
+- **A hub-mesh rename propagates the mirror's `name`, not its `label` — "do not rename twice" was wrong** (`rules/device-lifecycle.md`, `skills/_reference/endpoints.md`). The rule's propagation claim was right and its closing directive was the actionable half, so the wrong half is the one readers acted on. A mirror's `label` is custom, overrides the propagated `name`, and is what every reader sees — the UI, device pickers, and any tool resolving by label. Measured on 2.5.1.156 across both hubs: renaming a mesh-shared soil probe on the source hub (`devices` 941, `Zone 8 Back Yard Plants Soil - Right Leg` → `… - Drainage Channel`) updated the mirror's `name` (`main` 1666) immediately and left its `label` untouched, still unchanged 15 minutes later and indefinitely thereafter. Following "do not rename twice" therefore produced a hub whose source and consumers disagreed. The consequence is not cosmetic, because a freed position name gets reused: this rename existed to free `Right Leg` for a replacement probe, and renaming only the source then pairing the replacement leaves the consuming hub holding two devices with the identical label, from which every label-resolving consumer picks one arbitrarily — on a soil-probe fleet, an app confidently reporting moisture for the wrong bed. The rule now states the rename is two operations, source first, and directs a `label` verification on the mirror after every source rename; the `Verify after removing` section is retitled `Verify after removing or renaming` to match what it now covers. Also adds the no-op round-trip directive for a device whose field set has not been round-tripped before — both renames here were verified that way first, and a mis-encoded mesh boolean pair unshares the device and deletes the mirror outright. Closes #119.
+
 ## 0.1.67 — 2026-08-13
 
 ### Changed

--- a/rules/device-lifecycle.md
+++ b/rules/device-lifecycle.md
@@ -37,11 +37,19 @@ them onto the new id.
 - Use the live audit before calling an enabled reference active or inert.
 - The usage script only reads — it never deletes. Deletion is irreversible: read the hub-UI confirm dialog's "in use by N apps" state with Playwright (`skills/_reference/playwright-ui.md`), then have the **user** perform the final removal — the agent guides and confirms, it does not click the destructive delete. A radio (Z-Wave/Zigbee) device also needs a physical exclusion/factory-reset only the user can do (`rules/zwave-zigbee-mesh.md`).
 
-## Verify after removing
+## Verify after removing or renaming
 
 - Re-read usage after the delete — do not assume the hub auto-pruned every reference type. Auto-pruning of app subscriptions is not guaranteed for dashboards, device inputs, or parent/child links.
 - A reference that survives the delete is a dangling pointer to fix on the referencing app.
-- **Hub-mesh mirrors are asymmetric across operations.** A `POST /device/update` rename **propagates** to the mirror on the consuming hub automatically; a delete does **not** — the mirror survives the source's removal and needs separate cleanup on the other hub (`skills/_reference/endpoints.md`). Do not over-correct into renaming twice.
+- **Hub-mesh mirrors are asymmetric across operations.** A `POST /device/update` rename propagates to the mirror's **`name`** on the consuming hub; a delete does not, and the mirror survives the source's removal (`skills/_reference/endpoints.md`).
+- A mirror's **`label`** is custom, overrides the propagated `name`, and changes only under an explicit rename on the consuming hub.
+- `label` is the field every reader sees — the UI, device pickers, and any tool resolving by label.
+- Renaming a mesh-shared device is TWO operations, source first.
+- Verify the mirror's `label` after every source rename.
+- Two devices sharing a `label` make every label-resolving consumer pick one of them arbitrarily.
+- Never leave a freed label duplicated when the source's old name is about to be reused.
+- Round-trip the field set with a no-op `POST /device/update` before the first real edit of any device.
+- A mis-encoded mesh boolean pair unshares the device and deletes the mirror (`skills/_reference/endpoints.md`).
 
 ## Replacement re-wires nothing
 

--- a/skills/_reference/endpoints.md
+++ b/skills/_reference/endpoints.md
@@ -241,7 +241,14 @@ The full field set: `name, label, zigbeeId, maxEvents, maxStates, spammyThreshol
 
 **Retention fields are display-tuned defaults.** `maxEvents` defaults to **11 per attribute** — 11 stored *changes*, not reports (`eventsJson` is change-filtered), so on a slow-moving signal it is a few hours and on a fast-changing one under an hour, rolled silently either way. `maxStates` 30, `spammyThreshold` 300. Raise `maxEvents` through this endpoint to use the hub as a short-horizon data buffer — 1000 covers ~two weeks of a slow-moving signal (`rules/data-collection.md`).
 
-**Hub-mesh mirrors follow a rename automatically** — all nine mirror `name` values updated on the consuming hub with no action there. This is the **opposite** of delete, where mirrors survive the source's removal and need cleanup on both hubs (`rules/device-lifecycle.md`): **rename propagates, delete does not.**
+**Hub-mesh mirrors follow a rename into `name` only — not into `label`.** All nine mirror `name` values updated on the consuming hub with no action there (2.5.1.135). A mirror's `label` is custom, overrides the propagated `name`, and is the field every reader sees — the UI, device pickers, and any tool resolving by label; it changes only under an explicit rename on the consuming hub. Re-measured on **2.5.1.156**, renaming a mesh-shared soil probe on the source hub (`devices` 941) via `POST /device/update`:
+
+| mirror field (`main` 1666) | before | after source rename |
+|--|--|--|
+| `name` | `… Right Leg on Devices In The New House…` | `… Drainage Channel on Devices In The New House…` — propagated immediately |
+| `label` | `Zone 8 Back Yard Plants Soil - Right Leg` | `Zone 8 Back Yard Plants Soil - Right Leg` — unchanged, still so 15 min later |
+
+So renaming a mesh-shared device is **two** operations, source first. Skipping the second leaves the source and every consumer on the other hub disagreeing, and it bites hardest when the freed name is reused: rename the source, pair the replacement, and the consuming hub holds **two devices with the identical label**, from which every label-resolving consumer picks one arbitrarily. This is still the **opposite** of delete, where mirrors survive the source's removal and need cleanup on both hubs (`rules/device-lifecycle.md`): **`name` propagates, `label` and delete do not.**
 
 **`zwaveRepair2` is a trigger, and polling it to read progress starts a rebuild.** It answers by
 state, which makes it look like a status route exactly once: idle → `{"success":true,"message":null}`


### PR DESCRIPTION
Closes #119.

`rules/device-lifecycle.md` told readers a `POST /device/update` rename propagates to the hub-mesh mirror and closed with **"Do not over-correct into renaming twice."** The propagation claim is right. The directive is wrong, and it is the half a reader acts on.

## What actually propagates

The mirror's **`name`** propagates. Its **`label`** does not — and `label` is what every reader sees: the UI, device pickers, and any tool resolving devices by label.

Measured on 2.5.1.156, renaming a mesh-shared soil probe on the source hub:

| mirror field (`main` 1666) | before | after source rename |
|--|--|--|
| `name` | `… Right Leg on Devices In The New House…` | `… Drainage Channel on …` ✅ propagated immediately |
| `label` | `Zone 8 Back Yard Plants Soil - Right Leg` | `Zone 8 Back Yard Plants Soil - Right Leg` ❌ unchanged 15 min later |

## Why it is consequential rather than cosmetic

A freed position name gets reused. This rename existed to free `Right Leg` for a replacement probe. Rename the source only, pair the replacement, and the consuming hub carries **two devices with the identical label** — every label-resolving consumer then picks one arbitrarily, which on a soil-probe fleet means an app confidently reporting moisture for the wrong bed.

## Changes

- `rules/device-lifecycle.md` — the mirror bullet is split into atomic directives: `name` propagates, `label` is custom and overrides it, the rename is TWO operations (source first), verify the mirror's `label` after every source rename, never leave a freed label duplicated. Section retitled `Verify after removing or renaming` to match what it now covers (still 6 H2 sections).
- Adds the no-op round-trip directive for a device whose field set has not been round-tripped — a mis-encoded mesh boolean pair unshares the device and deletes the mirror outright.
- `skills/_reference/endpoints.md` — the mirror paragraph carries the measured before/after table and the duplicate-label consequence; the summary line becomes **`name` propagates, `label` and delete do not**.
- `CHANGELOG.md` — un-headed `### Fixed` block for the stamp step.

## Verification

`pyright` 0 findings · 389 unit tests OK · `tessl plugin lint` valid. No code changed — this is a rule/reference correction.