### PR TITLE
chore(deps): refresh the pinned CI actions and dev tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
       - name: Install dev tooling
@@ -37,7 +37,7 @@ jobs:
   plugin:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - name: Install Tessl CLI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### Changed
+
+- **Refreshed the pinned CI actions and dev tooling** (`.github/workflows/ci.yml`, `requirements-dev.txt`). `actions/checkout` v4.2.2 → **v7.0.1**, `actions/setup-python` v5.3.0 → **v7.0.0**, `pyright` 1.1.408 → **1.1.411**. All three were sitting in open Dependabot PRs (#8 since 2026-07-14, #54 / #55 since 2026-07-21) that could never merge: this repo has **zero Dependabot secrets configured**, so `TESSL_TOKEN` and `FLEET_DISPATCH_TOKEN` do not exist in a Dependabot-triggered run, and the `plugin` job's skill-review step plus the `trigger` job's dispatch step fail on every Dependabot PR regardless of what it changes. The `test` job — the one that actually exercises the bump — passed on all three. The bumps are therefore landed here, where the run gets secrets and a real review, and the Dependabot PRs are closed as superseded. Action SHAs verified against the upstream tags before use (`actions/checkout` v7.0.1 = `3d3c42e…`, `actions/setup-python` v7.0.0 = `5fda3b9…`). The pyright bump is the only one with real breakage risk, since a type-checker bump can surface new findings; the zero-findings gate was run at 1.1.411 against the current tree and stayed clean, and the 574-test suite passes.
+- **Standing issue worth a decision:** every future Dependabot PR here hits the same wall. Adding `TESSL_TOKEN` and `FLEET_DISPATCH_TOKEN` as **Dependabot** secrets would fix it, at the cost of exposing both tokens to dependency-update runs. Left as the operator's call rather than changed unilaterally.
+
 ## 0.1.80 — 2026-08-31
 
 ### Fixed

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,3 @@
 # Dev/CI tooling. Runtime scripts are stdlib-only; this is only for the CI gates.
 # Renewed via .github/dependabot.yml (pip ecosystem).
-pyright==1.1.408
+pyright==1.1.411


### PR DESCRIPTION
**This PR is explicitly scoped as a CI change** (`rules/ci-safety.md` Hands Off CI Config) — the functional diff is `.github/workflows/ci.yml` and `requirements-dev.txt`, plus the `CHANGELOG.md` entry that `rules/context-artifacts.md` CHANGELOG Hygiene requires for a user-visible change. No other files.

| dependency | from | to |
|---|---|---|
| `actions/checkout` | v4.2.2 | **v7.0.1** |
| `actions/setup-python` | v5.3.0 | **v7.0.0** |
| `pyright` | 1.1.408 | **1.1.411** |

All three are the current latest.

## Why not just merge the Dependabot PRs

#8, #54 and #55 have been open since July carrying exactly these bumps. They can never merge, and it has nothing to do with their content:

```
$ gh api repos/jbaruch/hubitat-dev/dependabot/secrets --jq .total_count
0
```

No Dependabot secrets are configured, so `TESSL_TOKEN` and `FLEET_DISPATCH_TOKEN` don't exist in a Dependabot-triggered run. The failures are exactly the two secret-consuming steps:

- `plugin` → **Skill review (changed only)** fails (needs `TESSL_TOKEN`)
- `trigger` → **Dispatch the single-PR review** fails (needs `FLEET_DISPATCH_TOKEN`)

The `test` job — the one that actually exercises the bump — **passed on all three**. So this is structural, not a signal about the versions. Landing them here gets a run with secrets and a real policy review; the three Dependabot PRs get closed as superseded.

## Verification

- **SHAs checked against the upstream tags**, not taken on faith: `actions/checkout` v7.0.1 = `3d3c42e5aac5ba805825da76410c181273ba90b1`, `actions/setup-python` v7.0.0 = `5fda3b95a4ea91299a34e894583c3862153e4b97`.
- **pyright is the only one with real breakage risk** — a type-checker bump can surface new findings and red the gate. Ran the exact CI gate at 1.1.411 against the current tree: `0 errors, 0 warnings, 0 informations`. 574 tests pass.
- Both action bumps cross majors, but this workflow's usage is the drop-in surface only (`fetch-depth: 0` on checkout, `python-version: "3.11"` on setup-python); the majors are Node-runtime bumps.

## One decision left for you

Every *future* Dependabot PR here hits the same wall. Adding `TESSL_TOKEN` and `FLEET_DISPATCH_TOKEN` as **Dependabot** secrets would fix it permanently, at the cost of exposing both tokens to dependency-update runs. That's a security tradeoff I've left as your call rather than making it unilaterally — noted in the CHANGELOG.

Supersedes #8, #54, #55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gyWsgxwTNHzvLJeDmQUq5
